### PR TITLE
Add basic temporary Admin Router dashboards

### DIFF
--- a/dashboards/AdminRouter/AdminRouter-Details-Upstreams.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Upstreams.json
@@ -1,0 +1,4546 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.1.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1549278819279,
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "overview"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "icon": "external link",
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "summary",
+        "adminrouter"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter"
+      ],
+      "title": "Admin Router Details",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 81,
+      "panels": [],
+      "title": "Admin Router Master",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 19,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_server_requests_total{host=\"*\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_server_request_seconds{host=\"*\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Admin Router Nginx Load: $master_prometheus",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 48,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_server_requests_total{host=\"*\",code=\"5xx\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_server_requests_total{host=\"*\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "D"
+        },
+        {
+          "expr": "max((rate(nginx_vts_server_requests_total{host=\"*\",code=\"4xx\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_server_requests_total{host=\"*\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_server_requests_total{host=\"*\",code=\"3xx\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_server_requests_total{host=\"*\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_server_requests_total{host=\"*\",code=\"2xx\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_server_requests_total{host=\"*\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Admin Router Nginx Status Percentage: $master_prometheus",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 83,
+      "panels": [],
+      "title": "IAM",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 47,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"iam\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{upstream=\"iam\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "IAM Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 49,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"iam\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"iam\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"iam\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"iam\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"iam\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"iam\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"iam\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"iam\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "IAM Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 95,
+      "panels": [],
+      "title": "CockroachDB",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 60,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"cockroachdb\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{upstream=\"cockroachdb\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CockroachDB Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 61,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"cockroachdb\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"cockroachdb\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"cockroachdb\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"cockroachdb\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"cockroachdb\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"cockroachdb\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"cockroachdb\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"cockroachdb\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CockroachDB Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 91,
+      "panels": [],
+      "title": "Cosmos",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 54,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:7070\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{backend=~\"[^ ]+:7070\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cosmos Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 55,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:7070\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:7070\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:7070\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:7070\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:7070\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:7070\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:7070\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:7070\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cosmos Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 107,
+      "panels": [],
+      "title": "DC/OS CA",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "id": 72,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"certificate_authority\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{upstream=\"certificate_authority\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS CA Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 73,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"certificate_authority\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"certificate_authority\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"certificate_authority\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"certificate_authority\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"certificate_authority\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"certificate_authority\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"certificate_authority\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"certificate_authority\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS CA Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 101,
+      "panels": [],
+      "title": "DC/OS Diagnostics",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 66,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"dcos_diagnostics\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{upstream=\"dcos_diagnostics\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS Diagnostics Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 67,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"dcos_diagnostics\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"dcos_diagnostics\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"dcos_diagnostics\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"dcos_diagnostics\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"dcos_diagnostics\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"dcos_diagnostics\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"dcos_diagnostics\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"dcos_diagnostics\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS Diagnostics Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 109,
+      "panels": [],
+      "title": "DC/OS Licensing",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 74,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"licensing\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{upstream=\"licensing\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS Licensing Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 75,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"licensing\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"licensing\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"licensing\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"licensing\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"licensing\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"licensing\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"licensing\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"licensing\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS Licensing Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 99,
+      "panels": [],
+      "title": "DC/OS Net",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 64,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"dcos_net\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{upstream=\"dcos_net\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS Net Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 50
+      },
+      "id": 65,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"dcos_net\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"dcos_net\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"dcos_net\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"dcos_net\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"dcos_net\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"dcos_net\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"dcos_net\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"dcos_net\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS Net Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "id": 111,
+      "panels": [],
+      "title": "DC/OS Registry",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 76,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"registry\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{upstream=\"registry\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS Registry Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 77,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"registry\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"registry\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"registry\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"registry\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"registry\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"registry\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"registry\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"registry\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS Registry Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 105,
+      "panels": [],
+      "title": "DC/OS Secrets",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 64
+      },
+      "id": 70,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"/run/dcos/dcos-secrets.sock\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{upstream=\"/run/dcos/dcos-secrets.sock\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS Secrets Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 64
+      },
+      "id": 71,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"/run/dcos/dcos-secrets.sock\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"/run/dcos/dcos-secrets.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"/run/dcos/dcos-secrets.sock\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"/run/dcos/dcos-secrets.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"/run/dcos/dcos-secrets.sock\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"/run/dcos/dcos-secrets.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"/run/dcos/dcos-secrets.sock\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"/run/dcos/dcos-secrets.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DC/OS Secrets Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "id": 93,
+      "panels": [],
+      "title": "Exhibitor",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 71
+      },
+      "id": 58,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"exhibitor\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{upstream=\"exhibitor\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Exhibitor Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 71
+      },
+      "id": 59,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"exhibitor\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"exhibitor\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"exhibitor\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"exhibitor\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"exhibitor\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"exhibitor\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"exhibitor\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"exhibitor\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Exhibitor Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 77
+      },
+      "id": 87,
+      "panels": [],
+      "title": "Marathon",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 78
+      },
+      "id": 52,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(8080|8443)\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{backend=~\"[^ ]+:(8080|8443)\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Marathon Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 78
+      },
+      "id": 53,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(8080|8443)\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(8080|8443)\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(8080|8443)\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(8080|8443)\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(8080|8443)\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(8080|8443)\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(8080|8443)\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(8080|8443)\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Marathon Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 84
+      },
+      "id": 85,
+      "panels": [],
+      "title": "Mesos",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 85
+      },
+      "id": 50,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:5050\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{backend=~\"[^ ]+:5050\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Mesos Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 85
+      },
+      "id": 51,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:5050\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:5050\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:5050\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:5050\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:5050\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:5050\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:5050\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:5050\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Mesos Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 91
+      },
+      "id": 97,
+      "panels": [],
+      "title": "MesosDNS",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 92
+      },
+      "id": 62,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"mesos_dns\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{upstream=\"mesos_dns\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "MesosDNS Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 92
+      },
+      "id": 63,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"mesos_dns\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"mesos_dns\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"mesos_dns\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"mesos_dns\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"mesos_dns\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"mesos_dns\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"mesos_dns\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"mesos_dns\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "MesosDNS Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 98
+      },
+      "id": 89,
+      "panels": [],
+      "title": "Metronome",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "id": 56,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(9090|9443)\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{backend=~\"[^ ]+:(9090|9443)\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Metronome Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 99
+      },
+      "id": 57,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(9090|9443)\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(9090|9443)\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(9090|9443)\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(9090|9443)\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(9090|9443)\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(9090|9443)\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(9090|9443)\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{backend=~\"[^ ]+:(9090|9443)\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Metronome Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 105
+      },
+      "id": 103,
+      "panels": [],
+      "title": "Pkgpanda",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 255, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de",
+        "Requests": "#7eb26d",
+        "total": "rgb(255, 0, 0)"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 106
+      },
+      "id": 68,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Latency",
+          "bars": false,
+          "fill": 0,
+          "linewidth": 1,
+          "stack": false,
+          "yaxis": 2
+        },
+        {
+          "alias": "total",
+          "stack": false,
+          "zindex": -3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"pkgpanda\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Throughput",
+          "refId": "B"
+        },
+        {
+          "expr": "max(nginx_vts_upstream_request_seconds{upstream=\"pkgpanda\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Latency",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Pkgpanda Upstream Load: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "1000",
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 106
+      },
+      "id": 69,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"pkgpanda\",code=\"5xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"pkgpanda\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"pkgpanda\",code=\"4xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"pkgpanda\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"pkgpanda\",code=\"3xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"pkgpanda\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "refId": "C"
+        },
+        {
+          "expr": "max((rate(nginx_vts_upstream_requests_total{upstream=\"pkgpanda\",code=\"2xx\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]) / ignoring(code) rate(nginx_vts_upstream_requests_total{upstream=\"pkgpanda\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Pkgpanda Upstream Status Percentage: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log % HTTP status",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [
+    "dc/os",
+    "detail",
+    "adminrouter",
+    "upstreams"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Node",
+        "multi": true,
+        "name": "node",
+        "options": [],
+        "query": "label_values(nginx_vts_info{dcos_component_name=\"Admin Router\"},host)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Prometheus Instance",
+        "multi": true,
+        "name": "master_prometheus",
+        "options": [],
+        "query": "label_values(nginx_vts_info{dcos_component_name=\"Admin Router\"},instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 2,
+        "includeAll": false,
+        "label": "Upstream",
+        "multi": false,
+        "name": "upstream",
+        "options": [],
+        "query": "label_values(nginx_vts_upstream_request_seconds{dcos_component_name=\"Admin Router\"},upstream)",
+        "refresh": 1,
+        "regex": "cockroachdb|iam",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "5m",
+          "value": "5m"
+        },
+        "hide": 0,
+        "label": "Rate Interval",
+        "name": "rate_interval",
+        "options": [
+          {
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": true,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          }
+        ],
+        "query": "30s,1m,5m,10m,30m,1h,6h,12h,1d",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "2019-01-31T23:17:08.849Z",
+    "to": "2019-02-01T01:33:07.935Z"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Admin Router Details Upstreams",
+  "uid": "adminrouter-details-upstreams",
+  "version": 3
+}

--- a/dashboards/AdminRouter/AdminRouter-Summary.json
+++ b/dashboards/AdminRouter/AdminRouter-Summary.json
@@ -1,0 +1,1133 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.1.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1549283084765,
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "overview"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter"
+      ],
+      "title": "Admin Router Details",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "id": 23,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Live nodes",
+          "yaxis": 1
+        },
+        {
+          "alias": "All nodes",
+          "yaxis": 1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count(nginx_vts_info{dcos_component_name=\"Admin Router\",host=~\"$node\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Number of live instances",
+          "refId": "C",
+          "step": 120
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Instances: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "Count",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Number of Admin Router instances running on DC/OS master nodes. This should always match the number of expected DC/OS master nodes in the cluster.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 24,
+      "links": [],
+      "mode": "markdown",
+      "title": "Admin Router Instance Count",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 7
+      },
+      "id": 29,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Live nodes",
+          "yaxis": 1
+        },
+        {
+          "alias": "All nodes",
+          "yaxis": 1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "time() - nginx_vts_start_time_seconds{dcos_component_name=\"Admin Router\",host=~\"$node\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{host}}",
+          "refId": "C",
+          "step": 120
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Uptime: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "s",
+          "label": "",
+          "logBase": 10,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Admin Router uptime on a logarithmic scale.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "id": 16,
+      "links": [],
+      "mode": "markdown",
+      "title": "Admin Router Uptime",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 14
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "nginx_vts_main_connections{status=~\"active\",dcos_component_name=\"Admin Router\",host=~\"$node\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{host}}",
+          "refId": "C",
+          "step": 120
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Active Connections: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": "1024",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Number of connections managed by Admin Router. Active connections are the important metrics here since the DC/OS configuration limits them to a maximum of 1024. Beyond this number no new connections will be opened.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "id": 14,
+      "links": [],
+      "mode": "markdown",
+      "title": "Admin Router Active Connections",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 21
+      },
+      "id": 25,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Live nodes",
+          "yaxis": 1
+        },
+        {
+          "alias": "All nodes",
+          "yaxis": 1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "nginx_vts_server_request_seconds{host=\"*\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"} * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latency: $master_prometheus",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": "800",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "In Flight Requests",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Admin Router latency to process a request averaged per second.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 21
+      },
+      "id": 26,
+      "links": [],
+      "mode": "markdown",
+      "title": "Admin Router Latency",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 4,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 28
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Live nodes",
+          "yaxis": 1
+        },
+        {
+          "alias": "All nodes",
+          "yaxis": 1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(nginx_vts_server_requests_total{host=\"*\",code=\"total\",dcos_component_name=\"Admin Router\",instance=~\"$master_prometheus\"}[$rate_interval])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput: $master_prometheus",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "In Flight Requests",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Admin Router throughput measured as request rate per second.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 28
+      },
+      "id": 30,
+      "links": [],
+      "mode": "markdown",
+      "title": "Admin Router Throughput",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 4,
+      "grid": {},
+      "gridPos": {
+        "h": 12,
+        "w": 16,
+        "x": 0,
+        "y": 35
+      },
+      "id": 22,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": false,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Live nodes",
+          "yaxis": 1
+        },
+        {
+          "alias": "All nodes",
+          "yaxis": 1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"iam\",backend=\"127.0.0.1:8101\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Bouncer",
+          "refId": "C",
+          "step": 120
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"mesos_dns\",backend=\"127.0.0.1:8123\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "MesosDNS",
+          "refId": "A"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"pkgpanda\",backend=\"unix:/run/dcos/pkgpanda-api.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Pkgpanda",
+          "refId": "B"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"log\",backend=\"unix:/run/dcos/dcos-log.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "DC/OS Log",
+          "refId": "D"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"dcos_diagnostics\",backend=\"unix:/run/dcos/dcos-diagnostics.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "DC/OS Diagnostics",
+          "refId": "E"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"licensing\",backend=\"unix:/run/dcos/dcos-licensing.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "DC/OS Licensing",
+          "refId": "F"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"/run/dcos/dcos-secrets.sock\",backend=\"unix:/run/dcos/dcos-secrets.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "DC/OS Secrets",
+          "refId": "G"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"cluster_linker\",backend=\"unix:/run/dcos/dcos-cluster-linker.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Cluster Linker",
+          "refId": "H"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"exhibitor\",backend=\"127.0.0.1:8181\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Exhibitor",
+          "refId": "I"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"dcos_net\",backend=\"127.0.0.1:62080\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "DC/OS Net",
+          "refId": "J"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"certificate_authority\",backend=\"127.0.0.1:8888\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "DC/OS CA",
+          "refId": "K"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"cockroachdb\",backend=\"127.0.0.1:8090\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "CockroachDB",
+          "refId": "L"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"registry\",backend=\"127.0.0.1:5001\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Registry",
+          "refId": "M"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"backup\",backend=\"unix:/run/dcos/dcos-backup-master.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Backup",
+          "refId": "N"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"metrics\",backend=\"unix:/run/dcos/telegraf-dcos-metrics.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Metrics",
+          "refId": "O"
+        },
+        {
+          "expr": "max(rate(nginx_vts_upstream_requests_total{upstream=\"dcos_checks_api\",backend=\"unix:/run/dcos/dcos-checks-api.sock\",code=\"total\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "DC/OS Checks API",
+          "refId": "P"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Upstream Throughput: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Throughput per upstream measured as requests per second going to each upstream server.",
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 16,
+        "y": 35
+      },
+      "id": 20,
+      "links": [],
+      "mode": "markdown",
+      "title": "Admin Router Upstream Throughput",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 4,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 47
+      },
+      "id": 27,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Live nodes",
+          "yaxis": 1
+        },
+        {
+          "alias": "All nodes",
+          "yaxis": 1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "nginx_vts_main_shm_usage_bytes{shared=\"used_size\",dcos_component_name=\"Admin Router\",instance=~\"$node\",url=\"https://127.0.0.1/nginx/metrics\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{host}}",
+          "refId": "C",
+          "step": 120
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "VTS Module Shared Memory Size: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": "Shared memory size",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Size of shared memory region used by the VTS module to store metrics. The maximum size is set to 32MB for each Admin Router instance. In case the maximum shared memory size is reached the Admin Router will crash and reload, all metrics stored in memory will be reset.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 47
+      },
+      "id": 28,
+      "links": [],
+      "mode": "markdown",
+      "title": "Admin Router VTS Module Shared Memory Size",
+      "type": "text"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [
+    "dc/os",
+    "summary",
+    "adminrouter"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Node",
+        "multi": false,
+        "name": "node",
+        "options": [],
+        "query": "label_values(nginx_vts_info{dcos_component_name=\"Admin Router\"},host)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Prometheus Instance",
+        "multi": false,
+        "name": "master_prometheus",
+        "options": [],
+        "query": "label_values(nginx_vts_info{dcos_component_name=\"Admin Router\"},instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "5m",
+          "value": "5m"
+        },
+        "hide": 0,
+        "label": "Rate Interval",
+        "name": "rate_interval",
+        "options": [
+          {
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": true,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          }
+        ],
+        "query": "30s,1m,5m,10m,30m,1h,6h,12h,1d",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "2019-01-31T23:00:00.000Z",
+    "to": "2019-02-01T01:35:54.399Z"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Admin Router Summary",
+  "uid": "adminrouter-summary",
+  "version": 5
+}


### PR DESCRIPTION
This PR adds basic Admin Router (Master) dashboards that will later on be replaced by more detailed dashboards once we get around finishing the fine-grained Nginx metrics.

Corresponding ticket: [DCOS-47853](https://jira.mesosphere.com/browse/DCOS-47853)