### PR TITLE
Changed Telegraf dashboard rate interval defaults to 2m

### DIFF
--- a/dashboards/Telegraf-Agent.json
+++ b/dashboards/Telegraf-Agent.json
@@ -708,8 +708,9 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "text": "1m",
-          "value": "1m"
+          "selected": true,
+          "text": "2m",
+          "value": "2m"
         },
         "hide": 0,
         "label": "Rate Interval",
@@ -721,9 +722,14 @@
             "value": "30s"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "1m",
             "value": "1m"
+          },
+          {
+            "selected": true,
+            "text": "2m",
+            "value": "2m"
           },
           {
             "selected": false,
@@ -761,7 +767,7 @@
             "value": "1d"
           }
         ],
-        "query": "30s,1m,5m,10m,30m,1h,6h,12h,1d",
+        "query": "30s,1m,2m,5m,10m,30m,1h,6h,12h,1d",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"

--- a/dashboards/Telegraf-Input.json
+++ b/dashboards/Telegraf-Input.json
@@ -431,17 +431,23 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "text": "1m",
-          "value": "1m"
+          "selected": true,
+          "text": "2m",
+          "value": "2m"
         },
         "hide": 0,
         "label": "Rate Interval",
         "name": "rate_interval",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "1m",
             "value": "1m"
+          },
+          {
+            "selected": true,
+            "text": "2m",
+            "value": "2m"
           },
           {
             "selected": false,
@@ -479,7 +485,7 @@
             "value": "1d"
           }
         ],
-        "query": "1m,5m,10m,30m,1h,6h,12h,1d",
+        "query": "1m,2m,5m,10m,30m,1h,6h,12h,1d",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"

--- a/dashboards/Telegraf-Output.json
+++ b/dashboards/Telegraf-Output.json
@@ -670,17 +670,23 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "text": "1m",
-          "value": "1m"
+          "selected": true,
+          "text": "2m",
+          "value": "2m"
         },
         "hide": 0,
         "label": "Rate Interval",
         "name": "rate_interval",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "1m",
             "value": "1m"
+          },
+          {
+            "selected": true,
+            "text": "2m",
+            "value": "2m"
           },
           {
             "selected": false,
@@ -718,7 +724,7 @@
             "value": "1d"
           }
         ],
-        "query": "1m,5m,10m,30m,1h,6h,12h,1d",
+        "query": "1m,2m,5m,10m,30m,1h,6h,12h,1d",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"

--- a/dashboards/Telegraf-Runtime.json
+++ b/dashboards/Telegraf-Runtime.json
@@ -256,17 +256,23 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "text": "1m",
-          "value": "1m"
+          "selected": true,
+          "text": "2m",
+          "value": "2m"
         },
         "hide": 0,
         "label": "Rate Interval",
         "name": "rate_interval",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "1m",
             "value": "1m"
+          },
+          {
+            "selected": true,
+            "text": "2m",
+            "value": "2m"
           },
           {
             "selected": false,
@@ -304,7 +310,7 @@
             "value": "1d"
           }
         ],
-        "query": "1m,5m,10m,30m,1h,6h,12h,1d",
+        "query": "1m,2m,5m,10m,30m,1h,6h,12h,1d",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-49297
Modify the internal Telegraf dashboard default rate intervals to 2m to get the dashboards working with MWT clusters which use a larger rate interval than the previous dashboard default of 1m.