### PR TITLE
Fix query failure with `Node: All`

### DIFF
--- a/dashboards/Telegraf-Agent.json
+++ b/dashboards/Telegraf-Agent.json
@@ -683,7 +683,7 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,

--- a/dashboards/Telegraf-Input.json
+++ b/dashboards/Telegraf-Input.json
@@ -385,7 +385,7 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,

--- a/dashboards/Telegraf-Output.json
+++ b/dashboards/Telegraf-Output.json
@@ -779,7 +779,7 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,

--- a/dashboards/Telegraf-Runtime.json
+++ b/dashboards/Telegraf-Runtime.json
@@ -231,7 +231,7 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,


### PR DESCRIPTION
We need to explicitly set the 'custom all value' to '.*' so that the
URL doesn't contain all the nodes' names which leads to a too long URL
and eventually to a query error.