### PR TITLE
Complete overhaul of all Mesos related dashboards.

### DIFF
--- a/dashboards/Mesos-Agents-Summary.json
+++ b/dashboards/Mesos-Agents-Summary.json
@@ -51,7 +51,7 @@
   "description": "Show Mesos Agent metrics on a host",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 2,
   "id": null,
   "iteration": 1547665619735,
   "links": [],
@@ -66,113 +66,33 @@
       },
       "id": 18,
       "panels": [],
-      "title": "Basic",
+      "title": "Basic: $host",
       "type": "row"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": true,
-      "colorPostfix": false,
-      "colorPrefix": false,
-      "colorValue": false,
-      "colors": [
-        "#fceaca",
-        "#0a437c",
-        "#9ac48a"
-      ],
-      "datasource": "${DS_PROMETHEUS}",
-      "format": "dthms",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 1
-      },
-      "id": 4,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "Value",
-      "targets": [
-        {
-          "expr": "max(mesos_slave_uptime_secs{host=~\"$host\"})",
-          "format": "table",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Agent's uptime",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
     },
     {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": null,
       "fill": 1,
       "gridPos": {
         "h": 9,
-        "w": 10,
-        "x": 4,
+        "w": 12,
+        "x": 0,
         "y": 1
       },
-      "id": 41,
+      "id": 49,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
-        "current": false,
+        "current": true,
         "max": false,
         "min": false,
-        "show": false,
+        "rightSide": true,
+        "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -188,16 +108,119 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mesos_slave_frameworks_active{host=~\"$host\"}",
+          "expr": "mesos_slave_uptime_secs{host=~\"$host\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "{{host}}",
           "refId": "A"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Active frameworks",
+      "title": "Uptime",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "dthms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Shows the time in seconds since the last restart of the Mesos agent.\n\nThis metric should always increase. If the metric drops to zero, the agent has restarted.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 53,
+      "links": [],
+      "mode": "markdown",
+      "title": "Mesos Agent Uptime",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fill": 5,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 51,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "expr": "mesos_slave_registered{host=~\"$host\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Registered",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -215,15 +238,15 @@
         {
           "decimals": 0,
           "format": "short",
-          "label": "",
+          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
+          "max": "1",
+          "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": "",
+          "label": null,
           "logBase": 1,
           "max": null,
           "min": null,
@@ -236,6 +259,20 @@
       }
     },
     {
+      "content": "Whether this agent is registered with a master.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 54,
+      "links": [],
+      "mode": "markdown",
+      "title": "Registered",
+      "type": "text"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -244,19 +281,21 @@
       "fill": 1,
       "gridPos": {
         "h": 9,
-        "w": 10,
-        "x": 14,
-        "y": 1
+        "w": 12,
+        "x": 0,
+        "y": 19
       },
       "id": 39,
       "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -272,28 +311,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mesos_slave_recovery_errors{host=~\"$host\"}",
+          "expr": "sum(irate(mesos_slave_recovery_errors{host=~\"$host\"}[$rate]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "On agent recovery",
           "refId": "A"
         },
         {
-          "expr": "mesos_slave_container_launch_errors{host=~\"$host\"}",
+          "expr": "sum(irate(mesos_slave_container_launch_errors{host=~\"$host\"}[$rate]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "On container launch",
           "refId": "B"
         },
         {
-          "expr": "mesos_slave_invalid_status_updates{host=~\"$host\"}",
+          "expr": "sum(irate(mesos_slave_invalid_status_updates{host=~\"$host\"}[$rate]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "For status updates",
           "refId": "C"
         },
         {
-          "expr": "mesos_slave_invalid_framework_messages{host=~\"$host\"}",
+          "expr": "sum(irate(mesos_slave_invalid_framework_messages{host=~\"$host\"}[$rate]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "For framework messages",
@@ -303,7 +342,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Errors",
+      "title": "Error Rate ($rate)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -319,17 +358,17 @@
       },
       "yaxes": [
         {
-          "decimals": 0,
+          "decimals": null,
           "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
+          "label": "",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -342,274 +381,18 @@
       }
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "${DS_PROMETHEUS}",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 4
-      },
-      "id": 16,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "mesos_slave_registered{host=~\"$host\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Agent registered?",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "yes",
-          "value": "1"
-        },
-        {
-          "op": "=",
-          "text": "no",
-          "value": "0"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "id": 47,
-      "panels": [],
-      "title": "Mesos agent process",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 11
-      },
-      "id": 43,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": true,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "procstat_cpu_usage{process_name=\"mesos-agent\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{process_name}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "CPU usage",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "fill": 1,
+      "content": "Number of errors encountered per second, measured over $rate interval windows.\n\nTODO(tillt): Add expectation and interpretation hints.",
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 11
+        "y": 19
       },
-      "id": 45,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": true,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
+      "id": 55,
       "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "procstat_memory_rss{process_name=\"mesos-agent\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{process_name}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Memory usage",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "mode": "markdown",
+      "title": "Error Rate",
+      "type": "text"
     },
     {
       "collapsed": false,
@@ -617,11 +400,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 28
       },
       "id": 29,
       "panels": [],
-      "title": "Resources Summary",
+      "title": "Resources Summary: $host",
       "type": "row"
     },
     {
@@ -632,10 +415,10 @@
       "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
-        "h": 7,
-        "w": 24,
+        "h": 9,
+        "w": 12,
         "x": 0,
-        "y": 21
+        "y": 29
       },
       "id": 37,
       "legend": {
@@ -663,28 +446,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mesos_slave_cpus_percent{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_cpus_percent{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "CPUs",
           "refId": "A"
         },
         {
-          "expr": "mesos_slave_mem_percent{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_mem_percent{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Memory",
           "refId": "B"
         },
         {
-          "expr": "mesos_slave_disk_percent{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_disk_percent{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Disk",
           "refId": "C"
         },
         {
-          "expr": "mesos_slave_gpus_percent{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_gpus_percent{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "GPUs",
@@ -694,7 +477,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "% of allocated resources",
+      "title": "% of Allocated Resources",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -732,16 +515,30 @@
       }
     },
     {
+      "content": "Percentage of allocated or offered resources.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 56,
+      "links": [],
+      "mode": "markdown",
+      "title": "% of Allocated Resources",
+      "type": "text"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 38
       },
       "id": 20,
       "panels": [],
-      "title": "Resources Detailed",
+      "title": "Resources Detailed: $host",
       "type": "row"
     },
     {
@@ -755,7 +552,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 29
+        "y": 39
       },
       "id": 6,
       "legend": {
@@ -775,37 +572,49 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "Containers CPU Usage",
+          "yaxis": 2
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mesos_slave_cpus_total{host=~\"$host\"} + mesos_slave_cpus_revocable_total{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_cpus_total{host=~\"$host\"} + mesos_slave_cpus_revocable_total{host=~\"$host\"})",
           "format": "time_series",
+          "hide": false,
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Total CPUs with revocable",
+          "legendFormat": "Total CPUs",
           "refId": "A"
         },
         {
-          "expr": "mesos_slave_cpus_used{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_cpus_used{host=~\"$host\"})",
           "format": "time_series",
+          "hide": false,
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Used CPUs, non-revocable",
+          "legendFormat": "Offered or Allocated CPUs",
           "refId": "B"
         },
         {
-          "expr": "mesos_slave_cpus_revocable_used{host=~\"$host\"}",
+          "expr": "sum(irate(cpus_system_time_secs{host=~\"$host\"}[$rate]) + irate(cpus_user_time_secs{host=~\"$host\"}[$rate])) * sum(mesos_slave_cpus_total{host=~\"$host\"})",
           "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Used CPUs, revocable",
-          "refId": "C"
+          "legendFormat": "Containers CPU Usage",
+          "refId": "D"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "CPU allocation",
+      "title": "CPU Allocation and Usage",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -822,18 +631,19 @@
       "yaxes": [
         {
           "format": "short",
-          "label": null,
+          "label": "",
           "logBase": 1,
           "max": null,
           "min": null,
           "show": true
         },
         {
-          "format": "short",
-          "label": null,
+          "decimals": null,
+          "format": "percent",
+          "label": "",
           "logBase": 1,
-          "max": null,
-          "min": null,
+          "max": "100",
+          "min": "0",
           "show": true
         }
       ],
@@ -841,6 +651,20 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "content": "Number of CPUs in total and offered or allocated within the cluster. Additionally shows the percentage of total CPUs used by the container subsystem.\n\nThe amount of offered or allocated CPUs does contain a subset of CPUs for executors. Mesos does allow for the executor part to exceed resource limits.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 57,
+      "links": [],
+      "mode": "markdown",
+      "title": "CPU Allocation and Usage",
+      "type": "text"
     },
     {
       "aliasColors": {},
@@ -852,8 +676,8 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 29
+        "x": 0,
+        "y": 48
       },
       "id": 12,
       "legend": {
@@ -873,37 +697,43 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "Containers Memory Usage",
+          "yaxis": 1
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mesos_slave_mem_total{host=~\"$host\"} + mesos_slave_mem_revocable_total{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_mem_total{host=~\"$host\"} + mesos_slave_mem_revocable_total{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Total memory with revocable",
+          "legendFormat": "Total Memory",
           "refId": "A"
         },
         {
-          "expr": "mesos_slave_mem_used{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_mem_used{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Used memory, non-revocable",
+          "legendFormat": "Offered or Allocated Memory",
           "refId": "B"
         },
         {
-          "expr": "mesos_slave_mem_revocable_used{host=~\"$host\"}",
+          "expr": "sum(mem_total_bytes{host=~\"$host\"}) / 1000000",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Used memory, revocable",
-          "refId": "C"
+          "legendFormat": "Containers Memory Usage",
+          "refId": "D"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Memory allocation",
+      "title": "Memory Allocation and Usage",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -927,11 +757,12 @@
           "show": true
         },
         {
-          "format": "short",
+          "decimals": null,
+          "format": "decbytes",
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         }
       ],
@@ -939,6 +770,20 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "content": "Memory in total and offered or allocated within the cluster. Additionally shows the amount of memory used by containers.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "id": 58,
+      "links": [],
+      "mode": "markdown",
+      "title": "Memory Allocation and Usage",
+      "type": "text"
     },
     {
       "aliasColors": {},
@@ -951,105 +796,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 38
-      },
-      "id": 13,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "mesos_slave_disk_total{host=~\"$host\"} + mesos_slave_disk_revocable_total{host=~\"$host\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Total disk with revocable",
-          "refId": "A"
-        },
-        {
-          "expr": "mesos_slave_disk_used{host=~\"$host\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Used disk, non-revocable",
-          "refId": "B"
-        },
-        {
-          "expr": "mesos_slave_disk_revocable_used{host=~\"$host\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Used disk, revocable",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Disk allocation",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "decmbytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 38
+        "y": 57
       },
       "id": 14,
       "legend": {
@@ -1075,31 +822,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mesos_slave_gpus_total{host=~\"$host\"} + mesos_slave_gpus_revocable_total{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_gpus_total{host=~\"$host\"} + mesos_slave_gpus_revocable_total{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Total GPUs with revocable",
+          "legendFormat": "Total GPUs",
           "refId": "A"
         },
         {
-          "expr": "mesos_slave_gpus_used{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_gpus_used{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Used GPUs, non-revocable",
+          "legendFormat": "Offered or Allocated GPUs",
           "refId": "B"
-        },
-        {
-          "expr": "mesos_slave_gpus_revocable_used{host=~\"$host\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Used GPUs, revocable",
-          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "GPU allocation",
+      "title": "GPU Allocation",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1116,6 +856,119 @@
       "yaxes": [
         {
           "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Number of GPUs in total and offered or allocated within the cluster.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 59,
+      "links": [],
+      "mode": "markdown",
+      "title": "GPU Allocation",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 66
+      },
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(mesos_slave_disk_total{host=~\"$host\"} + mesos_slave_disk_revocable_total{host=~\"$host\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Total Disk",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(mesos_slave_disk_used{host=~\"$host\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Offered of Allocated Disk",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(disk_used_bytes{host=~\"$host\"}) / 1000000",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Container Disk Usage",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Disk Allocation and Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decmbytes",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1137,16 +990,30 @@
       }
     },
     {
+      "content": "Disk space in total and offered or allocated within the cluster. Additionally shows the amount of disk space used by containers.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 66
+      },
+      "id": 60,
+      "links": [],
+      "mode": "markdown",
+      "title": "Disk Allocation",
+      "type": "text"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 75
       },
       "id": 22,
       "panels": [],
-      "title": "Executors",
+      "title": "Executors: $host",
       "type": "row"
     },
     {
@@ -1155,12 +1022,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
+      "decimals": 0,
       "fill": 1,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 76
       },
       "id": 34,
       "legend": {
@@ -1184,25 +1052,25 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mesos_slave_executors_registering{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_executors_registering{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Registering",
           "refId": "A"
         },
         {
-          "expr": "mesos_slave_executors_running{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_executors_running{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Running",
           "refId": "B"
         },
         {
-          "expr": "mesos_slave_executors_terminating{host=~\"$host\"}",
+          "expr": "sum(mesos_slave_executors_terminating{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Terminating",
@@ -1212,7 +1080,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Active executors",
+      "title": "Active Executors",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1228,6 +1096,7 @@
       },
       "yaxes": [
         {
+          "decimals": 0,
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1250,6 +1119,20 @@
       }
     },
     {
+      "content": "Number of executors in an active state.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "id": 61,
+      "links": [],
+      "mode": "markdown",
+      "title": "Active Executors",
+      "type": "text"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -1259,8 +1142,8 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 48
+        "x": 0,
+        "y": 85
       },
       "id": 35,
       "legend": {
@@ -1288,14 +1171,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(mesos_slave_executors_terminated{host=~\"$host\"}[$rate])",
+          "expr": "sum(irate(mesos_slave_executors_terminated{host=~\"$host\"}[$rate]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Terminated",
           "refId": "A"
         },
         {
-          "expr": "rate(mesos_slave_executors_preempted{host=~\"$host\"}[$rate])",
+          "expr": "sum(irate(mesos_slave_executors_preempted{host=~\"$host\"}[$rate]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Preempted",
@@ -1305,7 +1188,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Terminal executors, rate over $rate window",
+      "title": "Terminal Executors Rate ($rate)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1325,7 +1208,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1343,16 +1226,30 @@
       }
     },
     {
+      "content": "Rate of executors terminated per second, measured over $rate interval windows.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 85
+      },
+      "id": 62,
+      "links": [],
+      "mode": "markdown",
+      "title": "Terminal Executors Rate",
+      "type": "text"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 94
       },
       "id": 24,
       "panels": [],
-      "title": "Tasks",
+      "title": "Tasks: $host",
       "type": "row"
     },
     {
@@ -1361,12 +1258,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
+      "decimals": 0,
       "fill": 1,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 95
       },
       "id": 32,
       "legend": {
@@ -1390,32 +1288,32 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(mesos_slave_tasks_staging{host=~\"$host\"}[$rate])",
+          "expr": "sum(mesos_slave_tasks_staging{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Staging",
           "refId": "A"
         },
         {
-          "expr": "rate(mesos_slave_tasks_starting{host=~\"$host\"}[$rate])",
+          "expr": "sum(mesos_slave_tasks_starting{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Starting",
           "refId": "B"
         },
         {
-          "expr": "rate(mesos_slave_tasks_running{host=~\"$host\"}[$rate])",
+          "expr": "sum(mesos_slave_tasks_running{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Running",
           "refId": "C"
         },
         {
-          "expr": "rate(mesos_slave_tasks_killing{host=~\"$host\"}[$rate])",
+          "expr": "sum(mesos_slave_tasks_killing{host=~\"$host\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Killing",
@@ -1425,7 +1323,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Active tasks, rate over $rate window",
+      "title": "Active Tasks",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1441,6 +1339,7 @@
       },
       "yaxes": [
         {
+          "decimals": 0,
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1463,6 +1362,20 @@
       }
     },
     {
+      "content": "Number of tasks in an active state.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 95
+      },
+      "id": 63,
+      "links": [],
+      "mode": "markdown",
+      "title": "Active Tasks",
+      "type": "text"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -1472,8 +1385,8 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 58
+        "x": 0,
+        "y": 104
       },
       "id": 33,
       "legend": {
@@ -1501,35 +1414,36 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(mesos_slave_tasks_finished{host=~\"$host\"}[$rate])",
+          "expr": "sum(irate(mesos_slave_tasks_finished{host=~\"$host\"}[$rate]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Finished",
           "refId": "A"
         },
         {
-          "expr": "rate(mesos_slave_tasks_failed{host=~\"$host\"}[$rate])",
+          "expr": "sum(irate(mesos_slave_tasks_failed{host=~\"$host\"}[$rate]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Failed",
           "refId": "B"
         },
         {
-          "expr": "rate(mesos_slave_tasks_gone{host=~\"$host\"}[$rate])",
+          "expr": "sum(irate(mesos_slave_tasks_gone{host=~\"$host\"}[$rate]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Gone",
           "refId": "C"
         },
         {
-          "expr": "rate(mesos_slave_tasks_killed{host=~\"$host\"}[$rate])",
+          "expr": "sum(irate(mesos_slave_tasks_killed{host=~\"$host\"}[$rate]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Killed",
           "refId": "D"
         },
         {
-          "expr": "rate(mesos_slave_tasks_lost{host=~\"$host\"}[$rate])",
+          "expr": "sum(irate(mesos_slave_tasks_lost{host=~\"$host\"}[$rate]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Lost",
@@ -1539,7 +1453,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Terminal tasks, rate over $rate window",
+      "title": "Terminal Tasks Rate ($rate)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1559,7 +1473,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1575,8 +1489,238 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "content": "Rate of tasks terminated per second, measured over 1h interval windows.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 104
+      },
+      "id": 64,
+      "links": [],
+      "mode": "markdown",
+      "title": "Terminal Tasks Rate",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 113
+      },
+      "id": 47,
+      "panels": [],
+      "repeat": null,
+      "title": "Mesos Agent Process: $host",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 114
+      },
+      "id": 43,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(procstat_cpu_usage{process_name=\"mesos-agent\", host=~\"$host\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "mesos-agent",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "The percentage of time that the \"mesos-agent\" process is active in any capacity.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 114
+      },
+      "id": 65,
+      "links": [],
+      "mode": "markdown",
+      "title": "Used Percent of Total CPU",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 123
+      },
+      "id": 45,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(procstat_memory_rss{process_name=\"mesos-agent\",host=~\"$host\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "mesos-agent",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Memory (RSS) Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "The amount of real memory (resident set) that the \"mesos-agent\" process is using.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 123
+      },
+      "id": 66,
+      "links": [],
+      "mode": "markdown",
+      "title": "Memory (RSS) Usage",
+      "type": "text"
     }
   ],
+  "refresh": "5m",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
@@ -1589,16 +1733,20 @@
     "list": [
       {
         "allValue": ".*",
-        "current": {},
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
-        "includeAll": false,
-        "label": null,
+        "includeAll": true,
+        "label": "Host",
         "multi": false,
         "name": "host",
         "options": [],
         "query": "label_values(mesos_slave_uptime_secs, host)",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -1617,7 +1765,7 @@
           "value": "1h"
         },
         "hide": 0,
-        "label": "Rate interval",
+        "label": "Rate Interval",
         "name": "rate",
         "options": [
           {
@@ -1725,5 +1873,5 @@
   "timezone": "",
   "title": "Mesos: Agents Summary",
   "uid": "b7b4c454b",
-  "version": 14
+  "version": 15
 }

--- a/dashboards/Mesos-Allocator-Summary.json
+++ b/dashboards/Mesos-Allocator-Summary.json
@@ -57,7 +57,7 @@
         "y": 0
       },
       "id": 18,
-      "title": "Basic",
+      "title": "Basic: [[percentile]]",
       "type": "row"
     },
     {
@@ -79,7 +79,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": true,
+        "show": false,
         "total": false,
         "values": false
       },
@@ -99,6 +99,7 @@
         {
           "expr": "mesos_allocator_mesos_allocation_run_ms_[[percentile]]{state=\"leader\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "$percentile",
           "refId": "A"
@@ -146,6 +147,20 @@
       }
     },
     {
+      "content": "Time spent in allocation algorithm.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 20,
+      "links": [],
+      "mode": "markdown",
+      "title": "Time spent in allocation algorithm",
+      "type": "text"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -155,8 +170,107 @@
       "gridPos": {
         "h": 9,
         "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mesos_allocator_mesos_allocation_runs{state=\"leader\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Allocation Runs",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "# of allocation runs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Number of times the allocation algorithm has run.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
         "x": 12,
-        "y": 1
+        "y": 10
+      },
+      "id": 21,
+      "links": [],
+      "mode": "markdown",
+      "title": "# of allocation runs",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 19
       },
       "id": 2,
       "legend": {
@@ -164,7 +278,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": true,
+        "show": false,
         "total": false,
         "values": false
       },
@@ -231,88 +345,18 @@
       }
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "fill": 1,
+      "content": "Allocation batch latency.\n\nTODO(tillt): Add expectation and interpretation hints.",
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 0,
-        "y": 10
+        "x": 12,
+        "y": 19
       },
-      "id": 11,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
+      "id": 22,
       "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "mesos_allocator_mesos_allocation_runs{state=\"leader\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "# of allocation runs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "mode": "markdown",
+      "title": "Allocation batch latency",
+      "type": "text"
     },
     {
       "aliasColors": {},
@@ -324,8 +368,8 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 10
+        "x": 0,
+        "y": 28
       },
       "id": 7,
       "legend": {
@@ -333,7 +377,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": true,
+        "show": false,
         "total": false,
         "values": false
       },
@@ -397,6 +441,20 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "content": "Allocator dispatch queue length.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 23,
+      "links": [],
+      "mode": "markdown",
+      "title": "Allocator dispatch queue length",
+      "type": "text"
     }
   ],
   "refresh": "1m",
@@ -412,7 +470,10 @@
     "list": [
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "text": "max",
+          "value": "max"
+        },
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
         "includeAll": false,
@@ -429,7 +490,7 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": true
+        "useTags": false
       }
     ]
   },
@@ -465,5 +526,5 @@
   "timezone": "",
   "title": "Mesos: Allocator Summary",
   "uid": "569efeb94",
-  "version": 8
+  "version": 9
 }

--- a/dashboards/Mesos-Containers-Details.json
+++ b/dashboards/Mesos-Containers-Details.json
@@ -1,0 +1,823 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.3.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Actual CPU/Memory/Disk usage of your containers.",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1544332110710,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 14,
+      "panels": [],
+      "title": "CPU: $service | $task_name | $host | $container_id",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "cpus_limit{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "CPU Limit ({{container_id}})",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(cpus_system_time_secs{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval]) + irate(cpus_user_time_secs{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "CPU Usage ({{container_id}})",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Total percentage of CPU time spent by tasks of the cgroup combined in kernel and user mode.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 20,
+      "links": [],
+      "mode": "markdown",
+      "title": "CPU Usage",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 10,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(cpus_nr_throttled{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval]) / irate(cpus_nr_periods{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "CPU Throttle ({{container_id}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU Throttling",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Rate of cgroup CPU throttle triggers, sampled over $rate_interval interval windows.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 21,
+      "links": [],
+      "mode": "markdown",
+      "title": "CPU Throttling",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Memory: $service | $task_name | $host | $container_id",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 8,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mem_limit_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Memory Limit ({{container_id}})",
+          "refId": "A"
+        },
+        {
+          "expr": "mem_total_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Memory Usage ({{container_id}})",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Memory size limit and memory used by container.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 22,
+      "links": [],
+      "mode": "markdown",
+      "title": "Memory Usage",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Disk:  $service | $task_name | $host | $container_id",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "disk_limit_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Disk Limit ({{container_id}})",
+          "refId": "A"
+        },
+        {
+          "expr": "disk_used_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Disk Usage ({{container_id}})",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Disk Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Disk space size limit and disk space used by container.\n\nTODO(tillt): Add expectation and interpretation hints. ",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 23,
+      "links": [],
+      "mode": "markdown",
+      "title": "Disk Usage",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 18,
+      "panels": [],
+      "title": "Network: $service | $task_name | $host | $container_id",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 6,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(net_rx_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Received ({{container_id}})",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(net_tx_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Sent ({{container_id}})",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Network",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Bytes per second sent and received via network.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 24,
+      "links": [],
+      "mode": "markdown",
+      "title": "Network",
+      "type": "text"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [
+    "dc/os",
+    "mesos",
+    "detail",
+    "container"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "dcos-monitoring",
+          "value": "dcos-monitoring"
+        },
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service Name",
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": "label_values(cpus_system_time_secs, service_name)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Task Name",
+        "multi": false,
+        "name": "task_name",
+        "options": [],
+        "query": "label_values(cpus_system_time_secs{service_name=~\"$service\"}, task_name)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "test-3",
+          "value": "test-3"
+        },
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Host",
+        "multi": false,
+        "name": "host",
+        "options": [],
+        "query": "label_values(cpus_system_time_secs{service_name=~\"$service\", task_name=~\"$task_name\"}, host)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Container ID",
+        "multi": false,
+        "name": "container_id",
+        "options": [],
+        "query": "label_values(cpus_system_time_secs{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\"}, container_id)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "selected": true,
+          "text": "2m",
+          "value": "2m"
+        },
+        "hide": 0,
+        "label": "Rate Interval",
+        "name": "rate_interval",
+        "options": [
+          {
+            "selected": true,
+            "text": "2m",
+            "value": "2m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          }
+        ],
+        "query": "2m,10m,30m",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Mesos: Container Details",
+  "uid": "mpivSaYiz",
+  "version": 61
+}

--- a/dashboards/Mesos-Containers-Summary.json
+++ b/dashboards/Mesos-Containers-Summary.json
@@ -45,11 +45,36 @@
   "description": "Actual CPU/Memory/Disk usage of your containers.",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 2,
   "id": null,
-  "iteration": 1544332110710,
-  "links": [],
+  "iteration": 1554390282996,
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "mesos",
+        "container",
+        "detail"
+      ],
+      "type": "dashboards"
+    }
+  ],
   "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 14,
+      "panels": [],
+      "title": "CPU: $service | $task_name | $host | $container_id",
+      "type": "row"
+    },
     {
       "aliasColors": {},
       "bars": false,
@@ -61,21 +86,32 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 1
       },
       "id": 4,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
-        "current": false,
-        "max": false,
+        "current": true,
+        "max": true,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
-      "links": [],
+      "links": [
+        {
+          "dashboard": "Mesos: Containers Details",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "Mesos: Containers Details",
+          "type": "dashboard",
+          "url": "/service/dcos-monitoring/grafana/d/kOFp4oemk/mesos-containers-details"
+        }
+      ],
       "nullPointMode": "null",
       "percentage": false,
       "pointradius": 5,
@@ -87,20 +123,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "cpus_limit{service_name=~\"$service_name\",executor_name=~\"$executor_name\",task_name=~\"$task_name\"}",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "CPU Limit (container {{container_id}}, {{host}})",
-          "refId": "A"
-        },
-        {
-          "expr": "rate(cpus_system_time_secs{service_name=~\"$service_name\",executor_name=~\"$executor_name\",task_name=~\"$task_name\"}[$rate_interval]) + rate(cpus_user_time_secs{service_name=~\"$service_name\",executor_name=~\"$executor_name\",task_name=~\"$task_name\"}[$rate_interval])",
+          "expr": "sum(cpus_limit{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "CPU Usage (container {{container_id}}, {{host}})",
+          "legendFormat": "CPU Limit",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(irate(cpus_system_time_secs{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval]) + irate(cpus_user_time_secs{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "CPU Usage",
           "refId": "B"
         }
       ],
@@ -145,6 +182,20 @@
       }
     },
     {
+      "content": "Total percentage of CPU time spent by tasks of the cgroup combined in kernel and user mode.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 20,
+      "links": [],
+      "mode": "markdown",
+      "title": "CPU Usage",
+      "type": "text"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -154,22 +205,33 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 0
+        "x": 0,
+        "y": 10
       },
       "id": 10,
       "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
-      "links": [],
+      "links": [
+        {
+          "dashboard": "Mesos: Containers Details",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "Mesos: Containers Details",
+          "type": "dashboard",
+          "url": "/service/dcos-monitoring/grafana/d/kOFp4oemk/mesos-containers-details"
+        }
+      ],
       "nullPointMode": "null",
       "percentage": false,
       "pointradius": 5,
@@ -181,11 +243,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(cpus_nr_throttled{service_name=~\"$service_name\",executor_name=~\"$executor_name\",task_name=~\"$task_name\"}[$rate_interval]) / rate(cpus_nr_periods{service_name=~\"$service_name\",executor_name=~\"$executor_name\",task_name=~\"$task_name\"}[$rate_interval]) * 100",
+          "expr": "sum(irate(cpus_nr_throttled{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval]) / irate(cpus_nr_periods{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "(container {{container_id}}, {{host}})",
+          "legendFormat": "CPU Throttle",
           "refId": "A"
         }
       ],
@@ -208,11 +270,11 @@
       },
       "yaxes": [
         {
-          "format": "percent",
+          "format": "percentunit",
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -230,6 +292,33 @@
       }
     },
     {
+      "content": "Rate of cgroup CPU throttle triggers, sampled over $rate_interval interval windows.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 21,
+      "links": [],
+      "mode": "markdown",
+      "title": "CPU Throttling",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Memory: $service | $task_name | $host | $container_id",
+      "type": "row"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -240,21 +329,32 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 9
+        "y": 20
       },
       "id": 8,
       "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
-      "links": [],
+      "links": [
+        {
+          "dashboard": "Mesos: Containers Details",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "Mesos: Containers Details",
+          "type": "dashboard",
+          "url": "/service/dcos-monitoring/grafana/d/kOFp4oemk/mesos-containers-details"
+        }
+      ],
       "nullPointMode": "null",
       "percentage": false,
       "pointradius": 5,
@@ -266,18 +366,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mem_limit_bytes{service_name=~\"$service_name\",executor_name=~\"$executor_name\",task_name=~\"$task_name\"}",
+          "expr": "sum(mem_limit_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Memory Limit (container {{container_id}}, {{host}})",
+          "legendFormat": "Memory Limit",
           "refId": "A"
         },
         {
-          "expr": "mem_total_bytes{service_name=~\"$service_name\",executor_name=~\"$executor_name\",task_name=~\"$task_name\"}",
+          "expr": "sum(mem_total_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Memory Usage (container {{container_id}}, {{host}})",
+          "legendFormat": "Memory Usage",
           "refId": "B"
         }
       ],
@@ -322,6 +423,33 @@
       }
     },
     {
+      "content": "Memory size limit and memory used by container.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 22,
+      "links": [],
+      "mode": "markdown",
+      "title": "Memory Usage",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Disk:  $service | $task_name | $host | $container_id",
+      "type": "row"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -331,22 +459,33 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 9
+        "x": 0,
+        "y": 30
       },
       "id": 2,
       "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
-      "links": [],
+      "links": [
+        {
+          "dashboard": "Mesos: Containers Details",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "Mesos: Containers Details",
+          "type": "dashboard",
+          "url": "/service/dcos-monitoring/grafana/d/kOFp4oemk/mesos-containers-details"
+        }
+      ],
       "nullPointMode": "null",
       "percentage": false,
       "pointradius": 5,
@@ -358,18 +497,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "disk_limit_bytes{service_name=~\"$service_name\",executor_name=~\"$executor_name\",task_name=~\"$task_name\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Disk Limit (container {{container_id}}, {{host}})",
-          "refId": "A"
-        },
-        {
-          "expr": "disk_used_bytes{service_name=~\"$service_name\",executor_name=~\"$executor_name\",task_name=~\"$task_name\"}",
+          "expr": "sum(disk_limit_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Disk Usage (container {{container_id}}, {{host}})",
+          "legendFormat": "Disk Limit",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(disk_used_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Disk Usage",
           "refId": "B"
         }
       ],
@@ -396,7 +536,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -414,6 +554,33 @@
       }
     },
     {
+      "content": "Disk space size limit and disk space used by container.\n\nTODO(tillt): Add expectation and interpretation hints. ",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 23,
+      "links": [],
+      "mode": "markdown",
+      "title": "Disk Usage",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 18,
+      "panels": [],
+      "title": "Network: $service | $task_name | $host | $container_id",
+      "type": "row"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -424,21 +591,32 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 40
       },
       "id": 6,
       "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
-      "links": [],
+      "links": [
+        {
+          "dashboard": "Mesos: Containers Details",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "Mesos: Containers Details",
+          "type": "dashboard",
+          "url": "/service/dcos-monitoring/grafana/d/kOFp4oemk/mesos-containers-details"
+        }
+      ],
       "nullPointMode": "null",
       "percentage": false,
       "pointradius": 5,
@@ -450,17 +628,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(net_rx_bytes{service_name=~\"$service_name\",executor_name=~\"$executor_name\",task_name=~\"$task_name\"}[$rate_interval])",
+          "expr": "sum(irate(net_rx_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Recv (container {{container_id}}, {{host}})",
+          "legendFormat": "Received",
           "refId": "A"
         },
         {
-          "expr": "rate(net_tx_bytes{service_name=~\"$service_name\",executor_name=~\"$executor_name\",task_name=~\"$task_name\"}[$rate_interval])",
+          "expr": "sum(irate(net_tx_bytes{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\", container_id=~\"$container_id\"}[$rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Sent (container {{container_id}}, {{host}})",
+          "legendFormat": "Sent",
           "refId": "B"
         }
       ],
@@ -487,7 +665,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -503,6 +681,20 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "content": "Bytes per second sent and received via network.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 24,
+      "links": [],
+      "mode": "markdown",
+      "title": "Network",
+      "type": "text"
     }
   ],
   "refresh": false,
@@ -511,42 +703,25 @@
   "tags": [
     "dc/os",
     "mesos",
-    "detail"
+    "container",
+    "summary"
   ],
   "templating": {
     "list": [
       {
         "allValue": ".*",
-        "current": {},
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
         "includeAll": true,
-        "label": null,
+        "label": "Service Name",
         "multi": false,
-        "name": "service_name",
+        "name": "service",
         "options": [],
-        "query": "label_values(service_name)",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": ".*",
-        "current": {},
-        "datasource": "${DS_PROMETHEUS}",
-        "hide": 0,
-        "includeAll": true,
-        "label": null,
-        "multi": false,
-        "name": "executor_name",
-        "options": [],
-        "query": "label_values(executor_name)",
+        "query": "label_values(cpus_system_time_secs, service_name)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -559,15 +734,66 @@
       },
       {
         "allValue": ".*",
-        "current": {},
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
         "includeAll": true,
-        "label": null,
+        "label": "Task Name",
         "multi": false,
         "name": "task_name",
         "options": [],
-        "query": "label_values(task_name)",
+        "query": "label_values(cpus_system_time_secs{service_name=~\"$service\"}, task_name)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Host",
+        "multi": false,
+        "name": "host",
+        "options": [],
+        "query": "label_values(cpus_system_time_secs{service_name=~\"$service\", task_name=~\"$task_name\"}, host)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Container ID",
+        "multi": false,
+        "name": "container_id",
+        "options": [],
+        "query": "label_values(cpus_system_time_secs{service_name=~\"$service\", task_name=~\"$task_name\", host=~\"$host\"}, container_id)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -587,7 +813,7 @@
           "value": "2m"
         },
         "hide": 0,
-        "label": null,
+        "label": "Rate Interval",
         "name": "rate_interval",
         "options": [
           {
@@ -643,7 +869,7 @@
     ]
   },
   "timezone": "",
-  "title": "Mesos: Container Details",
-  "uid": "mpivSaYiz",
-  "version": 60
+  "title": "Mesos: Containers Summary",
+  "uid": "_x5aKa6mz",
+  "version": 7
 }

--- a/dashboards/Mesos-Frameworks-Summary.json
+++ b/dashboards/Mesos-Frameworks-Summary.json
@@ -1,0 +1,921 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.0.1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 2,
+  "id": 46,
+  "iteration": 1554250721466,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 33,
+      "panels": [],
+      "title": "Basic: $framework",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": 0,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mesos_master_frameworks_subscribed_total{framework_name=~\"$framework\"}",
+          "format": "time_series",
+          "interval": "$rate",
+          "intervalFactor": 1,
+          "legendFormat": "{{framework_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Subscribed",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": "1",
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Shows whether not the framework has an active subscription with the Mesos master.\n\nThis metric should commonly remain steady at 1. If the metric drops to zero, the framework may have restarted and some time of unavailability might be observed afterwards.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 16,
+      "links": [],
+      "mode": "markdown",
+      "title": "Framework subscribed",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 28,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mesos_master_frameworks_roles_suppressed{framework_name=~\"$framework\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{framework_name}}: {{role_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Suppressing",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": "1",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "For each of the framework’s subscribed roles, whether or not offers for that role are currently suppressed.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 29,
+      "links": [],
+      "mode": "markdown",
+      "title": "Suppressing",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 31,
+      "panels": [],
+      "title": "Tasks: $framework",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": 0,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 10,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(mesos_master_frameworks_tasks_active{framework_name=~\"$framework\"}) by (task_state)",
+          "format": "time_series",
+          "interval": "$rate",
+          "intervalFactor": 1,
+          "legendFormat": "{{task_state}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Active Tasks",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Shows count of tasks in an active state.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 18,
+      "links": [],
+      "mode": "markdown",
+      "title": "Count of active state tasks",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(mesos_master_frameworks_tasks_terminal{framework_name=~\"$framework\"}[$rate])) by (task_state)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{task_state}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Terminal Tasks  Rate [$rate]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Shows count of tasks in a terminal state.\n\nTODO(tillt): Add expectation and interpretation hints. ",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 20,
+      "links": [],
+      "mode": "markdown",
+      "title": "Count of terminal state tasks",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 35,
+      "panels": [],
+      "title": "Performance: $framework",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(mesos_master_frameworks_offers_sent{framework_name=~\"$framework\"}[$rate])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Offers Rate ($rate)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Shows rate of offers per second sent by the leading master.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 22,
+      "links": [],
+      "mode": "markdown",
+      "title": "Rate of offers sent",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(mesos_master_frameworks_events{framework_name=~\"$framework\"}[$rate])) by (event_type)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{event_type}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Events Rate ($rate)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "This panel shows the rate of any kind of event received from the Mesos master.\n\nThis metric should commonly remain mostly flat and non-zero during normal framework operation.\n\nFor batch processing workloads, the rate might increase during load but should drop to its previous value after the operation is done. If operations are pending, but no offer events are observed, the service might be starved for resources. If this metric drops to zero, the service might have lost contact to the Mesos master and might need to be restarted.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "id": 24,
+      "links": [],
+      "mode": "markdown",
+      "title": "Rate of events received",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(mesos_master_frameworks_calls{framework_name=~\"$framework\"}[$rate])) by (call_type)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{call_type}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Calls Rate ($rate)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "This panel shows the rate of any kind of call sent by the framework per second.\n\nThis metric should commonly remain mostly flat and non-zero during normal framework operation.\n\nFor batch processing workloads, the rate might increase during load but should drop to its previous value after the operation is done. If operations are pending, but no offer events are observed, the service might be starved for resources. If this metric drops to zero, the service might have lost contact to the Mesos master and might need to be restarted.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 26,
+      "links": [],
+      "mode": "markdown",
+      "title": "Rate of calls sent",
+      "type": "text"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [
+    "dc/os",
+    "mesos",
+    "frameworks",
+    "summary"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Framework",
+        "multi": false,
+        "name": "framework",
+        "options": [],
+        "query": "label_values(mesos_master_frameworks_calls_total, framework_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "2m",
+          "value": "2m"
+        },
+        "hide": 0,
+        "label": "Rate Interval",
+        "name": "rate",
+        "options": [
+          {
+            "selected": true,
+            "text": "2m",
+            "value": "2m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "15m",
+            "value": "15m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "2h",
+            "value": "2h"
+          }
+        ],
+        "query": "2m,5m,15m,30m,1h,2h",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "2m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Mesos: Frameworks Summary",
+  "uid": "C3EFGTeiz",
+  "version": 1
+}

--- a/dashboards/Mesos-Masters-Summary.json
+++ b/dashboards/Mesos-Masters-Summary.json
@@ -50,80 +50,124 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 2,
   "id": null,
   "iteration": 1543441157459,
   "links": [],
   "panels": [
     {
-      "columns": [],
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 30,
+      "panels": [],
+      "title": "Basic",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "fontSize": "100%",
+      "fill": 1,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 1
       },
-      "id": 16,
+      "id": 22,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
       "links": [],
-      "pageSize": null,
-      "scroll": false,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": true
-      },
-      "styles": [
-        {
-          "alias": "Time",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "hidden"
-        },
-        {
-          "alias": "Uptime",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 1,
-          "pattern": "Value",
-          "thresholds": [],
-          "type": "number",
-          "unit": "dtdurations"
-        },
-        {
-          "alias": "",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 2,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
-          "unit": "short"
-        }
-      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "expr": "max(mesos_master_uptime_secs) by (instance)",
-          "format": "table",
-          "instant": true,
+          "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "{{instance}}",
           "refId": "A"
         }
       ],
-      "title": "Mesos Masters Uptime",
-      "transform": "table",
-      "type": "table"
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Master Uptime",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "dthms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Shows the time in seconds since the last restart of the Mesos masters.\n\nThis metric should always increase. If the metric drops to zero, the master has restarted and a reelection might be observed afterwards.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 32,
+      "links": [],
+      "mode": "markdown",
+      "title": "Mesos Master Uptime",
+      "type": "text"
     },
     {
       "aliasColors": {},
@@ -136,8 +180,8 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 0
+        "x": 0,
+        "y": 10
       },
       "id": 4,
       "legend": {
@@ -152,7 +196,7 @@
         "values": true
       },
       "lines": true,
-      "linewidth": 10,
+      "linewidth": 2,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
@@ -167,7 +211,7 @@
         {
           "expr": "mesos_master_elected",
           "format": "time_series",
-          "interval": "$min_interval",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -176,7 +220,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Mesos Master Election",
+      "title": "Leader Election",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -193,6 +237,7 @@
       },
       "yaxes": [
         {
+          "decimals": 0,
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -215,112 +260,31 @@
       }
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "fill": 1,
+      "content": "Whether a master is elected leader.\n\nTODO(tillt): Add expectation and interpretation hints.",
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 0,
-        "y": 9
+        "x": 12,
+        "y": 10
       },
-      "id": 6,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "max": true,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
+      "id": 33,
       "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(mesos_master_tasks_staging)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Staging",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(mesos_master_tasks_starting)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Starting",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(mesos_master_tasks_running)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Running",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(mesos_master_tasks_unreachable)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Unreachable",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Active tasks",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
+      "mode": "markdown",
+      "title": "Mesos Master Leader Election",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
       },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "id": 24,
+      "panels": [],
+      "title": "Mesos Master Process",
+      "type": "row"
     },
     {
       "aliasColors": {},
@@ -332,10 +296,10 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 9
+        "x": 0,
+        "y": 20
       },
-      "id": 10,
+      "id": 18,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -361,80 +325,23 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(mesos_master_tasks_finished)",
+          "expr": "procstat_cpu_usage{process_name=\"mesos-master\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Finished",
+          "legendFormat": "{{process_name}}",
           "refId": "A"
-        },
-        {
-          "expr": "sum(mesos_master_tasks_failed)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(mesos_master_tasks_gone)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Gone",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(mesos_master_tasks_gone_by_operator)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Gone by operator",
-          "refId": "D"
-        },
-        {
-          "expr": "sum(mesos_master_tasks_dropped)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Dropped",
-          "refId": "E"
-        },
-        {
-          "expr": "sum(mesos_master_tasks_killing)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Killing",
-          "refId": "F"
-        },
-        {
-          "expr": "sum(mesos_master_tasks_killed)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Killed",
-          "refId": "G"
-        },
-        {
-          "expr": "sum(mesos_master_tasks_lost)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Lost",
-          "refId": "H"
-        },
-        {
-          "expr": "sum(mesos_master_tasks_error)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Error",
-          "refId": "I"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Terminal tasks",
+      "title": "CPU Usage",
       "tooltip": {
         "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -445,11 +352,11 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "percent",
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": "0",
+          "min": null,
           "show": true
         },
         {
@@ -465,6 +372,20 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "content": "The percentage of time that the process is active in any capacity.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 34,
+      "links": [],
+      "mode": "markdown",
+      "title": "Used Percent of Total CPUs",
+      "type": "text"
     },
     {
       "aliasColors": {},
@@ -477,97 +398,12 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 29
       },
-      "id": 8,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(mesos_master_frameworks_active)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "frameworks",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Number of frameworks",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 18
-      },
-      "id": 12,
+      "id": 20,
       "legend": {
         "alignAsTable": true,
-        "avg": false,
+        "avg": true,
         "current": true,
         "max": true,
         "min": false,
@@ -590,51 +426,23 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(mesos_master_slaves_connected)",
+          "expr": "procstat_memory_rss{process_name=\"mesos-master\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Connected",
+          "legendFormat": "{{process_name}}",
           "refId": "A"
-        },
-        {
-          "expr": "sum(mesos_master_slaves_disconnected)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Disconnected",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(mesos_master_slaves_active)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Active",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(mesos_master_slaves_inactive)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Inactive",
-          "refId": "D"
-        },
-        {
-          "expr": "sum(mesos_master_slaves_unreachable)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Unreachable",
-          "refId": "E"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Number of agents",
+      "title": "Memory (RSS) Usage",
       "tooltip": {
         "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -667,6 +475,20 @@
       }
     },
     {
+      "content": "The amount of real memory (resident set) that the process is using.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 35,
+      "links": [],
+      "mode": "markdown",
+      "title": "Memory (RSS) Usage",
+      "type": "text"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -677,7 +499,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 38
       },
       "id": 14,
       "legend": {
@@ -727,7 +549,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Queue length",
+      "title": "Queue Length",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -766,19 +588,47 @@
       }
     },
     {
+      "content": "Number of dispatches in the event queue.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 36,
+      "links": [],
+      "mode": "markdown",
+      "title": "Queue Length",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "id": 28,
+      "panels": [],
+      "title": "Tasks",
+      "type": "row"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
+      "decimals": 0,
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 12,
-        "y": 27
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 48
       },
-      "id": 18,
+      "id": 6,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -804,23 +654,45 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "procstat_cpu_usage{process_name=\"mesos-master\"}",
+          "expr": "mesos_master_tasks_staging{state=\"leader\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{process_name}}",
+          "legendFormat": "Staging",
           "refId": "A"
+        },
+        {
+          "expr": "mesos_master_tasks_starting{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Starting",
+          "refId": "B"
+        },
+        {
+          "expr": "mesos_master_tasks_running{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Running",
+          "refId": "C"
+        },
+        {
+          "expr": "mesos_master_tasks_unreachable{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Unreachable",
+          "refId": "D"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "CPU usage",
+      "title": "Active Tasks",
       "tooltip": {
         "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -831,7 +703,8 @@
       },
       "yaxes": [
         {
-          "format": "percent",
+          "decimals": 0,
+          "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -853,6 +726,20 @@
       }
     },
     {
+      "content": "Number of tasks in an active state.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "id": 37,
+      "links": [],
+      "mode": "markdown",
+      "title": "Active Tasks",
+      "type": "text"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -860,12 +747,12 @@
       "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 27
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 57
       },
-      "id": 20,
+      "id": 10,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -891,23 +778,80 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "procstat_memory_rss{process_name=\"mesos-master\"}",
+          "expr": "irate(mesos_master_tasks_finished{state=\"leader\"}[$rate])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{process_name}}",
+          "legendFormat": "Finished",
           "refId": "A"
+        },
+        {
+          "expr": "irate(mesos_master_tasks_failed{state=\"leader\"}[$rate])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "refId": "B"
+        },
+        {
+          "expr": "irate(mesos_master_tasks_gone{state=\"leader\"}[$rate])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Gone",
+          "refId": "C"
+        },
+        {
+          "expr": "irate(mesos_master_tasks_gone_by_operator{state=\"leader\"}[$rate])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Gone by operator",
+          "refId": "D"
+        },
+        {
+          "expr": "irate(mesos_master_tasks_dropped{state=\"leader\"}[$rate])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Dropped",
+          "refId": "E"
+        },
+        {
+          "expr": "irate(mesos_master_tasks_killing{state=\"leader\"}[$rate])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Killing",
+          "refId": "F"
+        },
+        {
+          "expr": "irate(mesos_master_tasks_killed{state=\"leader\"}[$rate])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Killed",
+          "refId": "G"
+        },
+        {
+          "expr": "irate(mesos_master_tasks_lost{state=\"leader\"}[$rate])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Lost",
+          "refId": "H"
+        },
+        {
+          "expr": "irate(mesos_master_tasks_error{state=\"leader\"}[$rate])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Error",
+          "refId": "I"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Memory usage",
+      "title": "Terminal Task Rate ($rate)",
       "tooltip": {
         "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -922,7 +866,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -938,6 +882,288 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "content": "Tasks per second reaching a terminal state.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 38,
+      "links": [],
+      "mode": "markdown",
+      "title": "Terminal Task Rate",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 26,
+      "panels": [],
+      "title": "Cluster",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": 0,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 67
+      },
+      "id": 8,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mesos_master_frameworks_connected{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Connected",
+          "refId": "A"
+        },
+        {
+          "expr": "mesos_master_frameworks_disconnected{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Disconnected",
+          "refId": "B"
+        },
+        {
+          "expr": "mesos_master_frameworks_active{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Active",
+          "refId": "C"
+        },
+        {
+          "expr": "mesos_master_frameworks_inactive{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Inactive",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Number of Frameworks",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Number of frameworks.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 67
+      },
+      "id": 39,
+      "links": [],
+      "mode": "markdown",
+      "title": "Number of Frameworks",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": 0,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 76
+      },
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mesos_master_slaves_connected{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Connected",
+          "refId": "A"
+        },
+        {
+          "expr": "mesos_master_slaves_disconnected{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Disconnected",
+          "refId": "B"
+        },
+        {
+          "expr": "mesos_master_slaves_active{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Active",
+          "refId": "C"
+        },
+        {
+          "expr": "mesos_master_slaves_inactive{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Inactive",
+          "refId": "D"
+        },
+        {
+          "expr": "mesos_master_slaves_unreachable{state=\"leader\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Unreachable",
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Number of Agents",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Number of agents.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "id": 40,
+      "links": [],
+      "mode": "markdown",
+      "title": "Number of Agents",
+      "type": "text"
     }
   ],
   "refresh": "1m",
@@ -960,14 +1186,9 @@
           "value": "2m"
         },
         "hide": 0,
-        "label": "Interval",
-        "name": "min_interval",
+        "label": "Rate Interval",
+        "name": "rate",
         "options": [
-          {
-            "selected": true,
-            "text": "2m",
-            "value": "2m"
-          },
           {
             "selected": false,
             "text": "1m",
@@ -994,7 +1215,7 @@
             "value": "30m"
           }
         ],
-        "query": "2m, 1m,2m,5m,10m,30m",
+        "query": "1m,2m,5m,10m,30m",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"

--- a/dashboards/Mesos-Resources-Summary.json
+++ b/dashboards/Mesos-Resources-Summary.json
@@ -50,7 +50,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 2,
   "id": null,
   "links": [],
   "panels": [
@@ -77,18 +77,18 @@
       "fill": 1,
       "gridPos": {
         "h": 9,
-        "w": 16,
+        "w": 12,
         "x": 0,
         "y": 1
       },
       "id": 2,
       "legend": {
         "alignAsTable": true,
-        "avg": true,
+        "avg": false,
         "current": true,
         "max": true,
         "min": true,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": true
@@ -107,7 +107,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(mesos_allocator_mesos_resources_cpus_total)",
+          "expr": "mesos_allocator_mesos_resources_cpus_total",
           "format": "time_series",
           "interval": "5m",
           "intervalFactor": 1,
@@ -115,21 +115,35 @@
           "refId": "A"
         },
         {
-          "expr": "sum(mesos_allocator_mesos_resources_cpus_offered_or_allocated)",
+          "expr": "mesos_allocator_mesos_resources_cpus_offered_or_allocated",
           "format": "time_series",
           "interval": "5m",
           "intervalFactor": 1,
-          "legendFormat": "Offered or allocated ",
+          "legendFormat": "Offered or Allocated ",
           "refId": "B"
         },
         {
-          "expr": "mesos_allocator_quota_roles_resources_guarantee{role_name=~\"$role\", resource=\"cpus\"}",
+          "expr": "sum(mesos_allocator_quota_roles_resources_guarantee{resource=\"cpus\"})",
           "format": "time_series",
           "instant": false,
           "interval": "5m",
           "intervalFactor": 1,
-          "legendFormat": "Quota ($role)",
+          "legendFormat": "Quota Total",
           "refId": "C"
+        },
+        {
+          "expr": "sum(mesos_allocator_quota_roles_resources_offered_or_allocated{resource=\"cpus\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Quota Offered or Allocated",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(contain)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "E"
         }
       ],
       "thresholds": [],
@@ -174,17 +188,17 @@
       }
     },
     {
-      "content": "When an offer is sent to a framework, it is counted as allocated until the framework rejects it. Hence one may see oscillation.\n\nCPU Quota is occasionally reported at 2x it's actual value. This _may_ be because `mesos_exporter` is too slow and reports multiple times within a polling interval causing a double count. TBC.",
+      "content": "Total number of CPUs in the cluster, CPUs offered or allocated, CPUs assigned to quotas and CPUs offered or allocated against quotas.\n\nTODO(tillt): Add expectation and interpretation hints.",
       "gridPos": {
         "h": 9,
-        "w": 8,
-        "x": 16,
+        "w": 12,
+        "x": 12,
         "y": 1
       },
       "id": 13,
       "links": [],
       "mode": "markdown",
-      "title": "Mesos Resource Summary Hints",
+      "title": "CPUs",
       "type": "text"
     },
     {
@@ -196,17 +210,18 @@
       "fill": 1,
       "gridPos": {
         "h": 9,
-        "w": 16,
+        "w": 12,
         "x": 0,
         "y": 10
       },
       "id": 3,
       "legend": {
         "alignAsTable": true,
-        "avg": true,
+        "avg": false,
         "current": true,
         "max": true,
         "min": true,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": true
@@ -239,11 +254,18 @@
           "refId": "B"
         },
         {
-          "expr": "mesos_allocator_quota_roles_resources_guarantee{role_name=~\"$role\", resource=\"mem\"}",
+          "expr": "sum(mesos_allocator_quota_roles_resources_guarantee{role_name=~\"$role\", resource=\"mem\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Quota ($role)",
+          "legendFormat": "Quota Total",
           "refId": "C"
+        },
+        {
+          "expr": "sum(mesos_allocator_quota_roles_resources_offered_or_allocated{role_name=~\"$role\", resource=\"mem\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Quota Offered or Allocated",
+          "refId": "D"
         }
       ],
       "thresholds": [],
@@ -288,6 +310,20 @@
       }
     },
     {
+      "content": "Total amount of memory in the cluster, memory offered or allocated, memory assigned to quotas and memory offered or allocated against quotas.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 17,
+      "links": [],
+      "mode": "markdown",
+      "title": "Memory",
+      "type": "text"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -296,17 +332,18 @@
       "fill": 1,
       "gridPos": {
         "h": 9,
-        "w": 16,
+        "w": 12,
         "x": 0,
         "y": 19
       },
       "id": 4,
       "legend": {
         "alignAsTable": true,
-        "avg": true,
+        "avg": false,
         "current": true,
         "max": true,
         "min": true,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": true
@@ -388,6 +425,20 @@
       }
     },
     {
+      "content": "Total amount of disk space in the cluster, disk space offered or allocated, disk space assigned to quotas and disk space offered or allocated against quotas.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 18,
+      "links": [],
+      "mode": "markdown",
+      "title": "Disk",
+      "type": "text"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -397,7 +448,7 @@
       },
       "id": 11,
       "panels": [],
-      "title": "Quota Detailed",
+      "title": "Quota Detailed: $role",
       "type": "row"
     },
     {
@@ -408,8 +459,8 @@
       "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
-        "h": 11,
-        "w": 8,
+        "h": 9,
+        "w": 12,
         "x": 0,
         "y": 29
       },
@@ -420,6 +471,7 @@
         "current": true,
         "max": true,
         "min": false,
+        "rightSide": false,
         "show": true,
         "total": false,
         "values": true
@@ -438,31 +490,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(mesos_allocator_quota_roles_resources_guarantee{resource=\"cpus\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Total",
-          "refId": "A"
-        },
-        {
           "expr": "mesos_allocator_quota_roles_resources_guarantee{role_name=~\"$role\", resource=\"cpus\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "$role",
+          "legendFormat": "Quota ({{role_name}})",
           "refId": "B"
         },
         {
           "expr": "mesos_allocator_quota_roles_resources_offered_or_allocated{role_name=~\"$role\", resource=\"cpus\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Offered or allocated",
+          "legendFormat": "Offered or Allocated ({{role_name}})",
           "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "CPUs quota",
+      "title": "CPUs Quota",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -501,6 +547,20 @@
       }
     },
     {
+      "content": "Amount of CPUs guaranteed for role \"$role\" via quota.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 19,
+      "links": [],
+      "mode": "markdown",
+      "title": "CPUs Quota",
+      "type": "text"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -508,10 +568,10 @@
       "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
-        "h": 11,
-        "w": 8,
-        "x": 8,
-        "y": 29
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 38
       },
       "id": 7,
       "legend": {
@@ -538,31 +598,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(mesos_allocator_quota_roles_resources_guarantee{resource=\"mem\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Total",
-          "refId": "A"
-        },
-        {
           "expr": "mesos_allocator_quota_roles_resources_guarantee{role_name=~\"$role\", resource=\"mem\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "$role",
+          "legendFormat": "Quota ({{role_name}})",
           "refId": "B"
         },
         {
           "expr": "mesos_allocator_quota_roles_resources_offered_or_allocated{role_name=~\"$role\", resource=\"mem\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Offered or allocated",
+          "legendFormat": "Quota Offered or Allocated ({{role_name}})",
           "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Memory quota",
+      "title": "Memory Quota",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -601,6 +654,20 @@
       }
     },
     {
+      "content": "Amount of memory guaranteed for role \"high\" via quota.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 20,
+      "links": [],
+      "mode": "markdown",
+      "title": "Memory Quota",
+      "type": "text"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -608,10 +675,10 @@
       "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
-        "h": 11,
-        "w": 8,
-        "x": 16,
-        "y": 29
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 47
       },
       "id": 14,
       "legend": {
@@ -638,31 +705,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(mesos_allocator_quota_roles_resources_guarantee{resource=\"disk\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Total",
-          "refId": "A"
-        },
-        {
           "expr": "mesos_allocator_quota_roles_resources_guarantee{role_name=~\"$role\", resource=\"disk\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "$role",
+          "legendFormat": "Quota {{role_name}}",
           "refId": "B"
         },
         {
           "expr": "mesos_allocator_quota_roles_resources_offered_or_allocated{role_name=~\"$role\", resource=\"disk\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Offered or allocated",
+          "legendFormat": "Offered or Allocated {{role_name}}",
           "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Disk quota",
+      "title": "Disk Quota",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -699,9 +759,23 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "content": "Amount of disk space guaranteed for role \"high\" via quota.\n\nTODO(tillt): Add expectation and interpretation hints.",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 47
+      },
+      "id": 21,
+      "links": [],
+      "mode": "markdown",
+      "title": "Disk Quota",
+      "type": "text"
     }
   ],
-  "refresh": "1m",
+  "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
@@ -713,12 +787,11 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
-          "selected": true,
           "tags": [],
-          "text": "",
-          "value": ""
+          "text": "high",
+          "value": "high"
         },
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
@@ -728,10 +801,10 @@
         "name": "role",
         "options": [],
         "query": "label_values(mesos_allocator_quota_roles_resources_guarantee, role_name)",
-        "refresh": 0,
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -772,5 +845,5 @@
   "timezone": "",
   "title": "Mesos: Resources Summary",
   "uid": "7cf9ddb73",
-  "version": 8
+  "version": 9
 }


### PR DESCRIPTION
- introducing mesos-frameworks-summary -- plenty of drill down depending on each-other, usable for left to right drill down filtering
- introducing mesos-containers-summary -- a 1to1 copy of mesos-containers-details, with the exception the that the former shows summed values whereas the latter shows overlayed values
- made room for descriptions and interpretation hints for all graphs
- put things into rows where needed to make stuff easier to identify, given the volume of graphs on some dashboards
- made sure that dashboards that allow for "All" filter/variable selection do in fact use `".*"` as a custom value to ensure scalability for queries with unbound result-sets

All of this can be looked at in action in this exact version - please ping me for login details.