### PR TITLE
Admin Router Service Dashboards

### DIFF
--- a/dashboards/AdminRouter/AdminRouter-Details-Runtime.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Runtime.json
@@ -53,7 +53,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554471983517,
+  "iteration": 1554480042368,
   "links": [
     {
       "icon": "external link",
@@ -101,6 +101,20 @@
         "upstream"
       ],
       "title": "Upstream",
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "service"
+      ],
+      "title": "Service",
       "type": "dashboards"
     },
     {
@@ -1056,5 +1070,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Runtime",
   "uid": "adminrouter-details-runtime",
-  "version": 3
+  "version": 5
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Runtime.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Runtime.json
@@ -53,7 +53,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1553873109178,
+  "iteration": 1554382309032,
   "links": [
     {
       "icon": "external link",
@@ -960,27 +960,6 @@
         "useTags": false
       },
       {
-        "allValue": ".*",
-        "current": {},
-        "datasource": "${DS_PROMETHEUS}",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Prometheus Instance",
-        "multi": false,
-        "name": "master_prometheus",
-        "options": [],
-        "query": "label_values(nginx_vts_info{dcos_component_name=\"Admin Router\"},instance)",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
         "auto": false,
         "auto_count": 30,
         "auto_min": "10s",
@@ -1075,7 +1054,7 @@
     ]
   },
   "timezone": "",
-  "title": "Admin Router: Details Runtime",
+  "title": "/AdminRouter/AdminRouter-Details-Runtime",
   "uid": "adminrouter-details-runtime",
-  "version": 1
+  "version": 3
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Runtime.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Runtime.json
@@ -53,7 +53,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554480042368,
+  "iteration": 1554737149870,
   "links": [
     {
       "icon": "external link",
@@ -73,6 +73,20 @@
         "summary",
         "adminrouter"
       ],
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "traffic"
+      ],
+      "title": "",
       "type": "dashboards"
     },
     {
@@ -115,20 +129,6 @@
         "service"
       ],
       "title": "Service",
-      "type": "dashboards"
-    },
-    {
-      "asDropdown": false,
-      "icon": "external link",
-      "includeVars": true,
-      "keepTime": true,
-      "tags": [
-        "dc/os",
-        "detail",
-        "adminrouter",
-        "traffic"
-      ],
-      "title": "Admin Router Details",
       "type": "dashboards"
     }
   ],
@@ -941,7 +941,7 @@
       "type": "table"
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
@@ -978,6 +978,7 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
+          "selected": true,
           "text": "5m",
           "value": "5m"
         },
@@ -1068,7 +1069,7 @@
     ]
   },
   "timezone": "",
-  "title": "/AdminRouter/AdminRouter-Details-Runtime",
+  "title": "AdminRouter: Details Runtime",
   "uid": "adminrouter-details-runtime",
-  "version": 5
+  "version": 6
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Runtime.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Runtime.json
@@ -53,7 +53,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554382309032,
+  "iteration": 1554471983517,
   "links": [
     {
       "icon": "external link",

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1553873133387,
+  "iteration": 1554287661740,
   "links": [
     {
       "icon": "external link",
@@ -176,12 +176,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "Admin Router Details Server Responses",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Server Responses",
+          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/adminrouter-details-server-requests/admin-router-details-server-responses"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -318,12 +318,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "Admin Router Details Server Status",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Server Status",
+          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/adminrouter-details-server-status/admin-router-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -738,7 +738,7 @@
     ]
   },
   "timezone": "",
-  "title": "Admin Router: Details Server Responses",
+  "title": "/AdminRouter/AdminRouter-Details-Server-Responses",
   "uid": "adminrouter-details-server-responses",
-  "version": 4
+  "version": 2
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554472000267,
+  "iteration": 1554480064257,
   "links": [
     {
       "icon": "external link",
@@ -101,6 +101,20 @@
         "upstream"
       ],
       "title": "Upstream",
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "service"
+      ],
+      "title": "Service",
       "type": "dashboards"
     },
     {
@@ -201,7 +215,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -209,7 +223,7 @@
           "refId": "C"
         },
         {
-          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))-sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))-sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -217,7 +231,7 @@
           "refId": "B"
         },
         {
-          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -225,7 +239,7 @@
           "refId": "A"
         },
         {
-          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -233,7 +247,7 @@
           "refId": "E"
         },
         {
-          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -241,7 +255,7 @@
           "refId": "D"
         },
         {
-          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -249,7 +263,7 @@
           "refId": "F"
         },
         {
-          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{status=~\"$status\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{status=~\"$status\",backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -888,5 +902,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Server-Responses",
   "uid": "adminrouter-details-server-responses",
-  "version": 31
+  "version": 35
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554382321728,
+  "iteration": 1554472000267,
   "links": [
     {
       "icon": "external link",
@@ -133,6 +133,174 @@
   "panels": [
     {
       "aliasColors": {
+        "1-5s": "rgb(0, 0, 255)",
+        "1s-5s": "rgb(255, 113, 0)",
+        "200ms-1s": "rgb(255, 255, 0)",
+        "40ms-200ms": "rgb(0, 0, 255)",
+        "5-25s": "rgb(255, 125, 0)",
+        "5s-25s": "rgb(162, 63, 63)",
+        "8ms-40ms": "rgb(0, 120, 0)",
+        "<200ms": "rgb(255, 0, 255)",
+        "<8ms": "rgb(0, 255, 0)",
+        ">25s": "rgb(255, 25, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 56,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 120,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "type": "dashboard",
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
+        }
+      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": ">25s",
+          "refId": "C"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))-sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "5s-25s",
+          "refId": "B"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "1s-5s",
+          "refId": "A"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "200ms-1s",
+          "refId": "E"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "40ms-200ms",
+          "refId": "D"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "8ms-40ms",
+          "refId": "F"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "<8ms",
+          "refId": "G"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Latency: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log Percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
         "1xx": "rgb(255, 0, 255)",
         "2xx": "rgb(0, 255, 0)",
         "3xx": "rgb(0, 0, 255)",
@@ -150,10 +318,10 @@
       "fill": 6,
       "grid": {},
       "gridPos": {
-        "h": 7,
+        "h": 5,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 5
       },
       "id": 54,
       "legend": {
@@ -291,10 +459,10 @@
       "fill": 6,
       "grid": {},
       "gridPos": {
-        "h": 7,
+        "h": 6,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 10
       },
       "id": 51,
       "legend": {
@@ -398,10 +566,10 @@
       "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 16
       },
       "id": 52,
       "links": [],
@@ -488,10 +656,10 @@
       "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 14
+        "y": 16
       },
       "id": 45,
       "links": [],
@@ -720,5 +888,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Server-Responses",
   "uid": "adminrouter-details-server-responses",
-  "version": 16
+  "version": 31
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554480064257,
+  "iteration": 1554737214215,
   "links": [
     {
       "icon": "external link",
@@ -72,6 +72,32 @@
         "dc/os",
         "summary",
         "adminrouter"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "runtime"
+      ],
+      "title": "",
+      "type": "dashboards"
+    },
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "traffic"
       ],
       "type": "dashboards"
     },
@@ -115,32 +141,6 @@
         "service"
       ],
       "title": "Service",
-      "type": "dashboards"
-    },
-    {
-      "icon": "external link",
-      "includeVars": true,
-      "keepTime": true,
-      "tags": [
-        "dc/os",
-        "detail",
-        "adminrouter",
-        "traffic"
-      ],
-      "type": "dashboards"
-    },
-    {
-      "asDropdown": false,
-      "icon": "external link",
-      "includeVars": true,
-      "keepTime": true,
-      "tags": [
-        "dc/os",
-        "detail",
-        "adminrouter",
-        "runtime"
-      ],
-      "title": "Admin Router Details",
       "type": "dashboards"
     }
   ],
@@ -195,12 +195,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "dashboard": "AdminRouter: Details Server Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "title": "AdminRouter: Details Server Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -274,7 +274,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server Latency: $node",
+      "title": "Server HTTP Request Latency Distribution: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -358,12 +358,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "dashboard": "AdminRouter: Details Server Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "title": "AdminRouter: Details Server Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -413,7 +413,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server HTTP Status: $node",
+      "title": "Server HTTP Status Distribution: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -499,12 +499,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "dashboard": "AdminRouter: Details Server Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "title": "AdminRouter: Details Server Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -515,11 +515,11 @@
       "repeatDirection": "v",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,server) or sum(irate(nginx_upstream_status_requests_total{status=~\"$status\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,upstream)) by (status)",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,server) or sum(irate(nginx_upstream_status_requests_total{status=~\"$status\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,upstream) or sum(irate(nginx_service_status_requests_total{status=~\"$status\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,upstream)) by (status)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -530,7 +530,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server HTTP Responses: $node",
+      "title": "Server HTTP Response Status Code Rate: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -550,7 +550,7 @@
           "decimals": 2,
           "format": "none",
           "label": "Requests/s",
-          "logBase": 10,
+          "logBase": 1,
           "max": null,
           "min": null,
           "show": true
@@ -751,7 +751,7 @@
       "type": "table"
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
@@ -810,6 +810,7 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
+          "selected": true,
           "text": "5m",
           "value": "5m"
         },
@@ -900,7 +901,7 @@
     ]
   },
   "timezone": "",
-  "title": "/AdminRouter/AdminRouter-Details-Server-Responses",
+  "title": "AdminRouter: Details Server Responses",
   "uid": "adminrouter-details-server-responses",
-  "version": 35
+  "version": 14
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554287661740,
+  "iteration": 1554382321728,
   "links": [
     {
       "icon": "external link",
@@ -155,7 +155,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 49,
+      "id": 54,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -189,7 +189,6 @@
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
-      "repeat": null,
       "repeatDirection": "v",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -197,7 +196,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"5.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -205,7 +204,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"4.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -213,7 +212,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"3.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -221,7 +220,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"2.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -232,7 +231,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server HTTP Status: $node - $server",
+      "title": "Server HTTP Status: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -332,38 +331,24 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "v",
-      "seriesOverrides": [
-        {
-          "alias": "Latency",
-          "bars": false,
-          "fill": 0,
-          "linewidth": 1,
-          "stack": false,
-          "yaxis": 2
-        },
-        {
-          "alias": "total",
-          "stack": false,
-          "zindex": -3
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status)",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,server) or sum(irate(nginx_upstream_status_requests_total{status=~\"$status\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,upstream)) by (status)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
           "legendFormat": "{{status}}",
-          "refId": "B"
+          "refId": "A"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server HTTP Responses: $node - $server",
+      "title": "Server HTTP Responses: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -383,9 +368,9 @@
           "decimals": 2,
           "format": "none",
           "label": "Requests/s",
-          "logBase": 1,
+          "logBase": 10,
           "max": null,
-          "min": "0",
+          "min": null,
           "show": true
         },
         {
@@ -393,7 +378,7 @@
           "format": "ms",
           "label": "",
           "logBase": 1,
-          "max": "800",
+          "max": null,
           "min": "0",
           "show": false
         }
@@ -473,15 +458,23 @@
       ],
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_useragent_requests_total{server=~\"$server\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,useragent)",
+          "expr": "sum(irate(nginx_server_useragent_requests_total{status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,useragent)",
           "format": "time_series",
-          "instant": false,
           "intervalFactor": 1,
           "legendFormat": "<b>{{status}}</b>     {{useragent}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(nginx_upstream_useragent_requests_total{upstream=~\".*\",backend=\"\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,useragent)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "<b>{{status}}</b>     {{useragent}}",
+          "refId": "B"
         }
       ],
-      "title": "Useragent Request Rate: $status",
+      "title": "Server Useragent Request Rate: $status",
       "transform": "timeseries_aggregations",
       "type": "table"
     },
@@ -555,15 +548,23 @@
       ],
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_uri_requests_total{server=~\"$server\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,uri)",
+          "expr": "sum(irate(nginx_server_uri_requests_total{status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,uri)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
           "legendFormat": "<b>{{status}}</b>     {{uri}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(nginx_upstream_uri_requests_total{upstream=~\".*\",backend=\"\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,uri)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "<b>{{status}}</b>     {{uri}}",
+          "refId": "B"
         }
       ],
-      "title": "URI Request Rate: $status",
+      "title": "Server URI Request Rate: $status",
       "transform": "timeseries_aggregations",
       "type": "table"
     }
@@ -606,35 +607,14 @@
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
-        "includeAll": false,
-        "label": "Server",
-        "multi": false,
-        "name": "server",
-        "options": [],
-        "query": "label_values(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\"},server)",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": ".*",
-        "current": {},
-        "datasource": "${DS_PROMETHEUS}",
-        "hide": 0,
         "includeAll": true,
         "label": "HTTP Status",
         "multi": true,
         "name": "status",
         "options": [],
-        "query": "label_values(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\"},status)",
+        "query": "query_result(sum(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\"} ) by (status) or sum(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\"}) by (status))",
         "refresh": 2,
-        "regex": "",
+        "regex": "/\"([^\"]+)\"/",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
@@ -740,5 +720,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Server-Responses",
   "uid": "adminrouter-details-server-responses",
-  "version": 2
+  "version": 16
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554382339727,
+  "iteration": 1554472036479,
   "links": [
     {
       "icon": "external link",
@@ -159,7 +159,7 @@
       "grid": {},
       "gridPos": {
         "h": 5,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 1
       },
@@ -259,6 +259,175 @@
     },
     {
       "aliasColors": {
+        "1-5s": "rgb(0, 0, 255)",
+        "1s-5s": "rgb(255, 113, 0)",
+        "200ms-1s": "rgb(255, 255, 0)",
+        "40ms-200ms": "rgb(0, 0, 255)",
+        "5-25s": "rgb(255, 125, 0)",
+        "5s-25s": "rgb(162, 63, 63)",
+        "8ms-40ms": "rgb(0, 120, 0)",
+        "<200ms": "rgb(255, 0, 255)",
+        "<8ms": "rgb(0, 255, 0)",
+        ">25s": "rgb(255, 25, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 61,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 100,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Responses",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "/AdminRouter/AdminRouter-Details-Server-Responses",
+          "type": "dashboard",
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-adminrouter-details-server-responses"
+        }
+      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "node",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": ">25s",
+          "refId": "C"
+        },
+        {
+          "expr": "(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "5s-25s",
+          "refId": "B"
+        },
+        {
+          "expr": "(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "1s-5s",
+          "refId": "A"
+        },
+        {
+          "expr": "(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "200ms-1s",
+          "refId": "E"
+        },
+        {
+          "expr": "(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "40ms-200ms",
+          "refId": "D"
+        },
+        {
+          "expr": "(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "8ms-40ms",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "<8ms",
+          "refId": "G"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Upstream HTTP Latency: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log Percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
         "1xx": "rgb(255, 0, 255)",
         "2xx": "rgb(0, 255, 0)",
         "3xx": "rgb(0, 0, 255)",
@@ -277,8 +446,8 @@
       "grid": {},
       "gridPos": {
         "h": 5,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 1
       },
       "id": 59,
@@ -527,5 +696,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Server-Status",
   "uid": "adminrouter-details-server-status",
-  "version": 10
+  "version": 15
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554480107003,
+  "iteration": 1554737230999,
   "links": [
     {
       "icon": "external link",
@@ -66,6 +66,30 @@
         "dc/os",
         "summary",
         "adminrouter"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "runtime"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "traffic"
       ],
       "type": "dashboards"
     },
@@ -109,30 +133,6 @@
         "service"
       ],
       "title": "Service",
-      "type": "dashboards"
-    },
-    {
-      "icon": "external link",
-      "includeVars": true,
-      "keepTime": true,
-      "tags": [
-        "dc/os",
-        "detail",
-        "adminrouter",
-        "traffic"
-      ],
-      "type": "dashboards"
-    },
-    {
-      "icon": "external link",
-      "includeVars": true,
-      "keepTime": true,
-      "tags": [
-        "dc/os",
-        "detail",
-        "adminrouter",
-        "runtime"
-      ],
       "type": "dashboards"
     }
   ],
@@ -198,13 +198,13 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Responses",
+          "dashboard": "AdminRouter: Details Server Responses",
           "includeVars": true,
           "keepTime": true,
           "targetBlank": false,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Responses",
+          "title": "AdminRouter: Details Server Responses",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-adminrouter-details-server-responses"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-details-server-responses"
         }
       ],
       "nullPointMode": "null",
@@ -212,7 +212,7 @@
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
-      "repeat": "node",
+      "repeat": null,
       "repeatDirection": "v",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -231,7 +231,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server Throughput",
+      "title": "Server HTTP Request Throughput - $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -321,12 +321,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Responses",
+          "dashboard": "AdminRouter: Details Server Responses",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Responses",
+          "title": "AdminRouter: Details Server Responses",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-adminrouter-details-server-responses"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-details-server-responses"
         }
       ],
       "nullPointMode": "null",
@@ -334,7 +334,7 @@
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
-      "repeat": "node",
+      "repeat": null,
       "repeatDirection": "v",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -401,7 +401,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Upstream HTTP Latency: $node",
+      "title": "Server HTTP Request Latency Distribution - $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -485,12 +485,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Responses",
+          "dashboard": "AdminRouter: Details Server Responses",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Responses",
+          "title": "AdminRouter: Details Server Responses",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-adminrouter-details-server-responses"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-details-server-responses"
         }
       ],
       "nullPointMode": "null",
@@ -498,6 +498,7 @@
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
+      "repeat": null,
       "repeatDirection": "v",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -540,7 +541,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server HTTP Status",
+      "title": "Server HTTP Status Distribution - $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -580,7 +581,7 @@
       }
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
@@ -618,6 +619,7 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
+          "selected": true,
           "text": "5m",
           "value": "5m"
         },
@@ -708,7 +710,7 @@
     ]
   },
   "timezone": "",
-  "title": "/AdminRouter/AdminRouter-Details-Server-Status",
+  "title": "AdminRouter: Details Server Status",
   "uid": "adminrouter-details-server-status",
-  "version": 16
+  "version": 11
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1553873597715,
+  "iteration": 1554287775194,
   "links": [
     {
       "icon": "external link",
@@ -184,13 +184,13 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "Admin Router Details Traffic",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Responses",
           "includeVars": true,
           "keepTime": true,
           "targetBlank": false,
-          "title": "Admin Router Details Traffic",
+          "title": "/AdminRouter/AdminRouter-Details-Server-Responses",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/whydwencsd/admin-router-details-traffic"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-adminrouter-details-server-responses"
         }
       ],
       "nullPointMode": "null",
@@ -302,12 +302,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "Admin Router Details Server Responses",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Responses",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Server Responses",
+          "title": "/AdminRouter/AdminRouter-Details-Server-Responses",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/adminrouter-details-server-requests/admin-router-details-server-responses"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-adminrouter-details-server-responses"
         }
       ],
       "nullPointMode": "null",
@@ -568,7 +568,7 @@
     ]
   },
   "timezone": "",
-  "title": "Admin Router: Details Server Status",
+  "title": "/AdminRouter/AdminRouter-Details-Server-Status",
   "uid": "adminrouter-details-server-status",
-  "version": 3
+  "version": 2
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554472036479,
+  "iteration": 1554480107003,
   "links": [
     {
       "icon": "external link",
@@ -95,6 +95,20 @@
         "upstream"
       ],
       "title": "Upstream",
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "service"
+      ],
+      "title": "Service",
       "type": "dashboards"
     },
     {
@@ -696,5 +710,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Server-Status",
   "uid": "adminrouter-details-server-status",
-  "version": 15
+  "version": 16
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554287775194,
+  "iteration": 1554382339727,
   "links": [
     {
       "icon": "external link",
@@ -133,8 +133,8 @@
       },
       "id": 26,
       "panels": [],
-      "repeat": "server",
-      "title": "$server",
+      "repeat": "node",
+      "title": "$node",
       "type": "row"
     },
     {
@@ -206,7 +206,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -217,7 +217,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server Throughput: $node",
+      "title": "Server Throughput",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -315,7 +315,6 @@
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
-      "repeat": "node",
       "repeatDirection": "v",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -323,7 +322,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"5.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -331,7 +330,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"4.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -339,7 +338,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"3.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -347,7 +346,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_requests_total{server=~\"$server\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"2.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -358,7 +357,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server HTTP Status: $node",
+      "title": "Server HTTP Status",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -410,27 +409,6 @@
   ],
   "templating": {
     "list": [
-      {
-        "allValue": ".*",
-        "current": {},
-        "datasource": "${DS_PROMETHEUS}",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Server",
-        "multi": true,
-        "name": "server",
-        "options": [],
-        "query": "label_values(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\"},server)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
       {
         "allValue": ".*",
         "current": {},
@@ -514,27 +492,6 @@
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
-      },
-      {
-        "allValue": "",
-        "current": {},
-        "datasource": "${DS_PROMETHEUS}",
-        "hide": 2,
-        "includeAll": true,
-        "label": "HTTP Error",
-        "multi": true,
-        "name": "http_error",
-        "options": [],
-        "query": "label_values(nginx_upstream_status_requests_total{dcos_component_name=\"Admin Router\"},status)",
-        "refresh": 2,
-        "regex": "40[^9]|5.*",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
       }
     ]
   },
@@ -570,5 +527,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Server-Status",
   "uid": "adminrouter-details-server-status",
-  "version": 2
+  "version": 10
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Service-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Service-Responses.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554737250170,
+  "iteration": 1554737279434,
   "links": [
     {
       "icon": "external link",
@@ -193,12 +193,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "dashboard": "AdminRouter: Details Service Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "title": "AdminRouter: Details Service Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-status/adminrouter-details-service-status"
         }
       ],
       "nullPointMode": "null",
@@ -207,14 +207,14 @@
       "points": false,
       "renderer": "flot",
       "repeat": null,
-      "repeatDirection": "v",
+      "repeatDirection": null,
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -222,7 +222,7 @@
           "refId": "C"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -230,7 +230,7 @@
           "refId": "B"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -238,7 +238,7 @@
           "refId": "A"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -246,7 +246,7 @@
           "refId": "E"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -254,7 +254,7 @@
           "refId": "D"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -262,7 +262,7 @@
           "refId": "F"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -273,7 +273,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Upstream HTTP Request Latency Distribution: $node - $upstream ($backend)",
+      "title": "Service HTTP Request Latency Distribution: $node - $service ($backend)",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -357,12 +357,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "AdminRouter: Details Upstream Status",
+          "dashboard": "AdminRouter: Details Service Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "AdminRouter: Details Upstream Status",
+          "title": "AdminRouter: Details Service Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-status/adminrouter-details-service-status"
         }
       ],
       "nullPointMode": "null",
@@ -378,7 +378,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\"$backend\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -386,7 +386,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\"$backend\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -394,7 +394,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\"$backend\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -402,7 +402,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\"$backend\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -413,7 +413,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Upstream HTTP Status Distribution: $node - $upstream ($backend)",
+      "title": "Service HTTP Status Distribution: $node - $service ($backend)",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -499,12 +499,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "AdminRouter: Details Upstream Status",
+          "dashboard": "AdminRouter: Details Service Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "AdminRouter: Details Upstream Status",
+          "title": "AdminRouter: Details Service Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-status/adminrouter-details-service-status"
         }
       ],
       "nullPointMode": "null",
@@ -520,7 +520,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status)",
+          "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\"$backend\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -531,7 +531,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Upstream HTTP Response Status Code Rate: $node - $upstream ($backend)",
+      "title": "Service HTTP Response Status Code Rate: $node - $service ($backend)",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -640,7 +640,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_useragent_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,useragent)",
+          "expr": "sum(irate(nginx_service_useragent_requests_total{service=~\"$service\",backend=~\"$backend\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,useragent)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -722,7 +722,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_uri_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,uri)",
+          "expr": "sum(irate(nginx_service_uri_requests_total{service=~\"$service\",backend=~\"$backend\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,uri)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -742,7 +742,7 @@
     "dc/os",
     "detail",
     "adminrouter",
-    "upstream",
+    "service",
     "responses"
   ],
   "templating": {
@@ -774,11 +774,11 @@
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
         "includeAll": false,
-        "label": "Upstream",
+        "label": "Service",
         "multi": false,
-        "name": "upstream",
+        "name": "service",
         "options": [],
-        "query": "label_values(nginx_upstream_backend_requests_total{dcos_component_name=\"Admin Router\"},upstream)",
+        "query": "label_values(nginx_service_status_requests_total{dcos_component_name=\"Admin Router\"},service)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -799,16 +799,16 @@
         "multi": true,
         "name": "backend",
         "options": [],
-        "query": "label_values(nginx_upstream_backend_requests_total{upstream=\"$upstream\",dcos_component_name=\"Admin Router\"},backend)",
+        "query": "label_values(nginx_service_status_requests_total{service=\"$service\",dcos_component_name=\"Admin Router\"},backend)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "label_values(nginx_upstream_backend_requests_total{upstream=\"$tag\",dcos_component_name=\"Admin Router\"},backend)",
+        "tagValuesQuery": "label_values(nginx_service_status_requests_total{service=\"$tag\",dcos_component_name=\"Admin Router\"},backend)",
         "tags": [
-          "IAM"
+          "marathon"
         ],
-        "tagsQuery": "label_values(nginx_upstream_backend_requests_total{upstream=\"$upstream\",dcos_component_name=\"Admin Router\"},upstream)",
+        "tagsQuery": "label_values(nginx_service_status_requests_total{service=\"$service\",dcos_component_name=\"Admin Router\"},service)",
         "type": "query",
         "useTags": true
       },
@@ -929,7 +929,7 @@
     ]
   },
   "timezone": "",
-  "title": "AdminRouter: Details Upstream Responses",
-  "uid": "adminrouter-details-upstream-responses",
-  "version": 13
+  "title": "AdminRouter: Details Service Responses",
+  "uid": "adminrouter-details-service-responses",
+  "version": 14
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Service-Status.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Service-Status.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554737262125,
+  "iteration": 1554737308011,
   "links": [
     {
       "icon": "external link",
@@ -194,13 +194,13 @@
           "linewidth": 1,
           "links": [
             {
-              "dashboard": "AdminRouter: Details Upstream Responses",
+              "dashboard": "AdminRouter: Details Service Responses",
               "includeVars": true,
               "keepTime": true,
               "targetBlank": false,
-              "title": "AdminRouter: Details Upstream Responses",
+              "title": "AdminRouter: Details Service Responses",
               "type": "dashboard",
-              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-upstream-responses"
+              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-responses/adminrouter-details-service-responses"
             }
           ],
           "nullPointMode": "null",
@@ -216,10 +216,10 @@
               "text": "ip-10-0-5-114.eu-west-1.compute.internal",
               "value": "ip-10-0-5-114.eu-west-1.compute.internal"
             },
-            "upstream": {
+            "service": {
               "selected": false,
-              "text": "CockroachDB",
-              "value": "CockroachDB"
+              "text": "beta-dcos-monitoring",
+              "value": "beta-dcos-monitoring"
             }
           },
           "seriesOverrides": [],
@@ -228,7 +228,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -239,7 +239,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Upstream Throughput: $node - $upstream",
+          "title": "Service HTTP Request Throughput: $node - $service",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -329,12 +329,12 @@
           "linewidth": 1,
           "links": [
             {
-              "dashboard": "AdminRouter: Details Upstream Responses",
+              "dashboard": "AdminRouter: Details Service Responses",
               "includeVars": true,
               "keepTime": true,
-              "title": "AdminRouter: Details Upstream Responses",
+              "title": "AdminRouter: Details Service Responses",
               "type": "dashboard",
-              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-upstream-responses"
+              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-responses/adminrouter-details-service-responses"
             }
           ],
           "nullPointMode": "null",
@@ -350,10 +350,10 @@
               "text": "ip-10-0-5-114.eu-west-1.compute.internal",
               "value": "ip-10-0-5-114.eu-west-1.compute.internal"
             },
-            "upstream": {
+            "service": {
               "selected": false,
-              "text": "CockroachDB",
-              "value": "CockroachDB"
+              "text": "beta-dcos-monitoring",
+              "value": "beta-dcos-monitoring"
             }
           },
           "seriesOverrides": [],
@@ -362,7 +362,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -370,7 +370,7 @@
               "refId": "C"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -378,7 +378,7 @@
               "refId": "B"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -386,7 +386,7 @@
               "refId": "A"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -394,7 +394,7 @@
               "refId": "E"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -402,7 +402,7 @@
               "refId": "D"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -410,7 +410,7 @@
               "refId": "F"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -421,7 +421,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Upstream HTTP Request Latency Distribution: $node - $upstream",
+          "title": "Service HTTP Request Latency Distribution: $node - $service",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -505,12 +505,12 @@
           "linewidth": 1,
           "links": [
             {
-              "dashboard": "AdminRouter: Details Upstream Responses",
+              "dashboard": "AdminRouter: Details Service Responses",
               "includeVars": true,
               "keepTime": true,
-              "title": "AdminRouter: Details Upstream Responses",
+              "title": "AdminRouter: Details Service Responses",
               "type": "dashboard",
-              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-upstream-responses"
+              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-responses/adminrouter-details-service-responses"
             }
           ],
           "nullPointMode": "null",
@@ -526,10 +526,10 @@
               "text": "ip-10-0-5-114.eu-west-1.compute.internal",
               "value": "ip-10-0-5-114.eu-west-1.compute.internal"
             },
-            "upstream": {
+            "service": {
               "selected": false,
-              "text": "CockroachDB",
-              "value": "CockroachDB"
+              "text": "beta-dcos-monitoring",
+              "value": "beta-dcos-monitoring"
             }
           },
           "seriesOverrides": [],
@@ -538,7 +538,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -546,7 +546,7 @@
               "refId": "C"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -554,7 +554,7 @@
               "refId": "B"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -562,7 +562,7 @@
               "refId": "A"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -570,7 +570,7 @@
               "refId": "E"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"1.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(rate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"1.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(rate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "D"
@@ -579,7 +579,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Upstream HTTP Status Distribution: $node - $upstream",
+          "title": "Service HTTP Status Distribution: $node - $service",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -644,7 +644,7 @@
             "x": 0,
             "y": 5
           },
-          "id": 110,
+          "id": 62,
           "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -665,13 +665,13 @@
           "linewidth": 1,
           "links": [
             {
-              "dashboard": "AdminRouter: Details Upstream Responses",
+              "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "includeVars": true,
               "keepTime": true,
               "targetBlank": false,
-              "title": "AdminRouter: Details Upstream Responses",
+              "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "type": "dashboard",
-              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-upstream-responses"
+              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-adminrouter-details-upstream-responses"
             }
           ],
           "nullPointMode": "null",
@@ -681,7 +681,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1554722012704,
+          "repeatIteration": 1554723754908,
           "repeatPanelId": 23,
           "scopedVars": {
             "node": {
@@ -689,10 +689,10 @@
               "text": "ip-10-0-7-165.eu-west-1.compute.internal",
               "value": "ip-10-0-7-165.eu-west-1.compute.internal"
             },
-            "upstream": {
+            "service": {
               "selected": false,
-              "text": "CockroachDB",
-              "value": "CockroachDB"
+              "text": "beta-dcos-monitoring",
+              "value": "beta-dcos-monitoring"
             }
           },
           "seriesOverrides": [],
@@ -701,7 +701,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -712,7 +712,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Upstream Throughput: $node - $upstream",
+          "title": "Upstream Throughput: $node",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -781,7 +781,7 @@
             "x": 8,
             "y": 5
           },
-          "id": 112,
+          "id": 64,
           "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -802,12 +802,12 @@
           "linewidth": 1,
           "links": [
             {
-              "dashboard": "AdminRouter: Details Upstream Responses",
+              "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "includeVars": true,
               "keepTime": true,
-              "title": "AdminRouter: Details Upstream Responses",
+              "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "type": "dashboard",
-              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-upstream-responses"
+              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-adminrouter-details-upstream-responses"
             }
           ],
           "nullPointMode": "null",
@@ -817,7 +817,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1554722012704,
+          "repeatIteration": 1554723754908,
           "repeatPanelId": 61,
           "scopedVars": {
             "node": {
@@ -825,10 +825,10 @@
               "text": "ip-10-0-7-165.eu-west-1.compute.internal",
               "value": "ip-10-0-7-165.eu-west-1.compute.internal"
             },
-            "upstream": {
+            "service": {
               "selected": false,
-              "text": "CockroachDB",
-              "value": "CockroachDB"
+              "text": "beta-dcos-monitoring",
+              "value": "beta-dcos-monitoring"
             }
           },
           "seriesOverrides": [],
@@ -837,7 +837,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -845,7 +845,7 @@
               "refId": "C"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -853,7 +853,7 @@
               "refId": "B"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -861,7 +861,7 @@
               "refId": "A"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -869,7 +869,7 @@
               "refId": "E"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -877,7 +877,7 @@
               "refId": "D"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -885,7 +885,7 @@
               "refId": "F"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -896,7 +896,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Upstream HTTP Request Latency Distribution: $node - $upstream",
+          "title": "Upstream HTTP Latency: $node",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -959,7 +959,7 @@
             "x": 16,
             "y": 5
           },
-          "id": 114,
+          "id": 66,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -980,12 +980,12 @@
           "linewidth": 1,
           "links": [
             {
-              "dashboard": "AdminRouter: Details Upstream Responses",
+              "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "includeVars": true,
               "keepTime": true,
-              "title": "AdminRouter: Details Upstream Responses",
+              "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "type": "dashboard",
-              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-upstream-responses"
+              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-adminrouter-details-upstream-responses"
             }
           ],
           "nullPointMode": "null",
@@ -995,7 +995,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1554722012704,
+          "repeatIteration": 1554723754908,
           "repeatPanelId": 59,
           "scopedVars": {
             "node": {
@@ -1003,10 +1003,10 @@
               "text": "ip-10-0-7-165.eu-west-1.compute.internal",
               "value": "ip-10-0-7-165.eu-west-1.compute.internal"
             },
-            "upstream": {
+            "service": {
               "selected": false,
-              "text": "CockroachDB",
-              "value": "CockroachDB"
+              "text": "beta-dcos-monitoring",
+              "value": "beta-dcos-monitoring"
             }
           },
           "seriesOverrides": [],
@@ -1015,7 +1015,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1023,7 +1023,7 @@
               "refId": "C"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1031,7 +1031,7 @@
               "refId": "B"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1039,7 +1039,7 @@
               "refId": "A"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1047,7 +1047,7 @@
               "refId": "E"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"1.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(rate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"1.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(rate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "D"
@@ -1056,7 +1056,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Upstream HTTP Status Distribution: $node - $upstream",
+          "title": "Service HTTP Status: $node",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -1121,7 +1121,7 @@
             "x": 0,
             "y": 9
           },
-          "id": 111,
+          "id": 63,
           "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -1142,13 +1142,13 @@
           "linewidth": 1,
           "links": [
             {
-              "dashboard": "AdminRouter: Details Upstream Responses",
+              "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "includeVars": true,
               "keepTime": true,
               "targetBlank": false,
-              "title": "AdminRouter: Details Upstream Responses",
+              "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "type": "dashboard",
-              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-upstream-responses"
+              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-adminrouter-details-upstream-responses"
             }
           ],
           "nullPointMode": "null",
@@ -1158,7 +1158,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1554722012704,
+          "repeatIteration": 1554723754908,
           "repeatPanelId": 23,
           "scopedVars": {
             "node": {
@@ -1166,10 +1166,10 @@
               "text": "ip-10-0-7-180.eu-west-1.compute.internal",
               "value": "ip-10-0-7-180.eu-west-1.compute.internal"
             },
-            "upstream": {
+            "service": {
               "selected": false,
-              "text": "CockroachDB",
-              "value": "CockroachDB"
+              "text": "beta-dcos-monitoring",
+              "value": "beta-dcos-monitoring"
             }
           },
           "seriesOverrides": [],
@@ -1178,7 +1178,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1189,7 +1189,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Upstream Throughput: $node - $upstream",
+          "title": "Upstream Throughput: $node",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -1258,7 +1258,7 @@
             "x": 8,
             "y": 9
           },
-          "id": 113,
+          "id": 65,
           "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -1279,12 +1279,12 @@
           "linewidth": 1,
           "links": [
             {
-              "dashboard": "AdminRouter: Details Upstream Responses",
+              "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "includeVars": true,
               "keepTime": true,
-              "title": "AdminRouter: Details Upstream Responses",
+              "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "type": "dashboard",
-              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-upstream-responses"
+              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-adminrouter-details-upstream-responses"
             }
           ],
           "nullPointMode": "null",
@@ -1294,7 +1294,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1554722012704,
+          "repeatIteration": 1554723754908,
           "repeatPanelId": 61,
           "scopedVars": {
             "node": {
@@ -1302,10 +1302,10 @@
               "text": "ip-10-0-7-180.eu-west-1.compute.internal",
               "value": "ip-10-0-7-180.eu-west-1.compute.internal"
             },
-            "upstream": {
+            "service": {
               "selected": false,
-              "text": "CockroachDB",
-              "value": "CockroachDB"
+              "text": "beta-dcos-monitoring",
+              "value": "beta-dcos-monitoring"
             }
           },
           "seriesOverrides": [],
@@ -1314,7 +1314,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1322,7 +1322,7 @@
               "refId": "C"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1330,7 +1330,7 @@
               "refId": "B"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1338,7 +1338,7 @@
               "refId": "A"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1346,7 +1346,7 @@
               "refId": "E"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1354,7 +1354,7 @@
               "refId": "D"
             },
             {
-              "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1362,7 +1362,7 @@
               "refId": "F"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_request_duration_seconds_bucket{service=~\"$service\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1373,7 +1373,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Upstream HTTP Request Latency Distribution: $node - $upstream",
+          "title": "Upstream HTTP Latency: $node",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -1436,7 +1436,7 @@
             "x": 16,
             "y": 9
           },
-          "id": 115,
+          "id": 67,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -1457,12 +1457,12 @@
           "linewidth": 1,
           "links": [
             {
-              "dashboard": "AdminRouter: Details Upstream Responses",
+              "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "includeVars": true,
               "keepTime": true,
-              "title": "AdminRouter: Details Upstream Responses",
+              "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
               "type": "dashboard",
-              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-upstream-responses"
+              "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-adminrouter-details-upstream-responses"
             }
           ],
           "nullPointMode": "null",
@@ -1472,7 +1472,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1554722012704,
+          "repeatIteration": 1554723754908,
           "repeatPanelId": 59,
           "scopedVars": {
             "node": {
@@ -1480,10 +1480,10 @@
               "text": "ip-10-0-7-180.eu-west-1.compute.internal",
               "value": "ip-10-0-7-180.eu-west-1.compute.internal"
             },
-            "upstream": {
+            "service": {
               "selected": false,
-              "text": "CockroachDB",
-              "value": "CockroachDB"
+              "text": "beta-dcos-monitoring",
+              "value": "beta-dcos-monitoring"
             }
           },
           "seriesOverrides": [],
@@ -1492,7 +1492,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1500,7 +1500,7 @@
               "refId": "C"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1508,7 +1508,7 @@
               "refId": "B"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1516,7 +1516,7 @@
               "refId": "A"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1524,7 +1524,7 @@
               "refId": "E"
             },
             {
-              "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"1.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(rate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+              "expr": "sum(irate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",status=~\"1.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(rate(nginx_service_status_requests_total{service=~\"$service\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "D"
@@ -1533,7 +1533,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Upstream HTTP Status Distribution: $node - $upstream",
+          "title": "Service HTTP Status: $node",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -1573,8 +1573,8 @@
           }
         }
       ],
-      "repeat": "upstream",
-      "title": "$upstream",
+      "repeat": "service",
+      "title": "$service",
       "type": "row"
     }
   ],
@@ -1585,7 +1585,7 @@
     "dc/os",
     "adminrouter",
     "detail",
-    "upstream",
+    "service",
     "status"
   ],
   "templating": {
@@ -1596,11 +1596,11 @@
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
         "includeAll": true,
-        "label": "Upstream",
+        "label": "Service",
         "multi": true,
-        "name": "upstream",
+        "name": "service",
         "options": [],
-        "query": "label_values(nginx_upstream_backend_requests_total{dcos_component_name=\"Admin Router\"},upstream)",
+        "query": "label_values(nginx_service_status_requests_total{dcos_component_name=\"Admin Router\"},service)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1728,7 +1728,7 @@
     ]
   },
   "timezone": "",
-  "title": "AdminRouter: Details Upstream Status",
-  "uid": "adminrouter-details-upstream-status",
-  "version": 12
+  "title": "AdminRouter: Details Service Status",
+  "uid": "adminrouter-details-service-status",
+  "version": 16
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
@@ -27,12 +27,6 @@
       "id": "prometheus",
       "name": "Prometheus",
       "version": "5.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": "5.0.0"
     }
   ],
   "annotations": {
@@ -53,7 +47,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554382292428,
+  "iteration": 1554471932059,
   "links": [
     {
       "icon": "external link",
@@ -119,6 +113,187 @@
   ],
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 56,
+      "panels": [],
+      "title": "Nginx",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1-5s": "rgb(0, 0, 255)",
+        "1s-5s": "rgb(255, 113, 0)",
+        "200ms-1s": "rgb(255, 255, 0)",
+        "40ms-200ms": "rgb(0, 0, 255)",
+        "5-25s": "rgb(255, 125, 0)",
+        "5s-25s": "rgb(162, 63, 63)",
+        "8ms-40ms": "rgb(0, 120, 0)",
+        "<200ms": "rgb(255, 0, 255)",
+        "<8ms": "rgb(0, 255, 0)",
+        ">25s": "rgb(255, 25, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 52,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 250,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "type": "dashboard",
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
+        }
+      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": ">25s",
+          "refId": "C"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))-sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "5s-25s",
+          "refId": "B"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "1s-5s",
+          "refId": "A"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "200ms-1s",
+          "refId": "E"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "40ms-200ms",
+          "refId": "D"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "8ms-40ms",
+          "refId": "F"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "<8ms",
+          "refId": "G"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Nginx Latency Distribution (sum): $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log Percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "aliasColors": {},
       "bars": true,
       "dashLength": 10,
@@ -129,20 +304,23 @@
       "fill": 4,
       "grid": {},
       "gridPos": {
-        "h": 7,
-        "w": 16,
+        "h": 6,
+        "w": 24,
         "x": 0,
-        "y": 0
+        "y": 6
       },
       "id": 18,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "hideEmpty": false,
         "hideZero": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
+        "sideWidth": 250,
         "total": false,
         "values": false
       },
@@ -220,82 +398,185 @@
       }
     },
     {
-      "columns": [
-        {
-          "text": "Current",
-          "value": "current"
-        },
-        {
-          "text": "Avg",
-          "value": "avg"
-        },
-        {
-          "text": "Max",
-          "value": "max"
-        }
-      ],
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fontSize": "90%",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 0
-      },
-      "hideTimeOverride": false,
-      "id": 46,
-      "links": [],
-      "pageSize": null,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": null,
-        "desc": false
-      },
-      "styles": [
-        {
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 2,
-          "pattern": ".*",
-          "thresholds": [],
-          "type": "number",
-          "unit": "reqps"
-        }
-      ],
-      "targets": [
-        {
-          "expr": "sum(rate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host) + sum(rate(nginx_upstream_status_requests_total{upstream=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{host}}",
-          "refId": "A",
-          "step": 240
-        }
-      ],
-      "title": "Throughput: $node",
-      "transform": "timeseries_aggregations",
-      "type": "table"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 12
       },
       "id": 32,
       "panels": [],
       "title": "Server",
       "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1-5s": "rgb(0, 0, 255)",
+        "1s-5s": "rgb(255, 113, 0)",
+        "200ms-1s": "rgb(255, 255, 0)",
+        "40ms-200ms": "rgb(0, 0, 255)",
+        "5-25s": "rgb(255, 125, 0)",
+        "5s-25s": "rgb(162, 63, 63)",
+        "8ms-40ms": "rgb(0, 120, 0)",
+        "<200ms": "rgb(255, 0, 255)",
+        "<8ms": "rgb(0, 255, 0)",
+        ">25s": "rgb(255, 25, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 54,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 250,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "type": "dashboard",
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
+        }
+      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": ">25s",
+          "refId": "C"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))-sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "5s-25s",
+          "refId": "B"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "1s-5s",
+          "refId": "A"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "200ms-1s",
+          "refId": "E"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "40ms-200ms",
+          "refId": "D"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) - sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "8ms-40ms",
+          "refId": "F"
+        },
+        {
+          "expr": "(sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))) / sum(sum(irate(nginx_server_status_request_duration_seconds_bucket{le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) + sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=\"\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "<8ms",
+          "refId": "G"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Latency Distribution (sum): $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log Percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -308,22 +589,23 @@
       "fill": 4,
       "grid": {},
       "gridPos": {
-        "h": 7,
-        "w": 16,
+        "h": 6,
+        "w": 24,
         "x": 0,
-        "y": 8
+        "y": 18
       },
       "id": 50,
       "legend": {
-        "alignAsTable": false,
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "hideEmpty": false,
         "hideZero": false,
         "max": false,
         "min": false,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
+        "sideWidth": 250,
         "total": false,
         "values": false
       },
@@ -350,7 +632,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,upstream)) by (host)",
+          "expr": "sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host) + sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -361,7 +643,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server Throughput: $node",
+      "title": "Server Throughput (sum): $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -401,71 +683,6 @@
       }
     },
     {
-      "columns": [
-        {
-          "text": "Current",
-          "value": "current"
-        },
-        {
-          "text": "Avg",
-          "value": "avg"
-        },
-        {
-          "text": "Max",
-          "value": "max"
-        }
-      ],
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fontSize": "90%",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 8
-      },
-      "hideTimeOverride": false,
-      "id": 51,
-      "links": [],
-      "pageSize": null,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": null,
-        "desc": false
-      },
-      "styles": [
-        {
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 2,
-          "pattern": ".*",
-          "thresholds": [],
-          "type": "number",
-          "unit": "reqps"
-        }
-      ],
-      "targets": [
-        {
-          "expr": "sum(rate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{host}}",
-          "refId": "A",
-          "step": 240
-        }
-      ],
-      "title": "Throughput: $node",
-      "transform": "timeseries_aggregations",
-      "type": "table"
-    },
-    {
       "aliasColors": {
         "1xx": "rgb(255, 0, 255)",
         "2xx": "rgb(0, 255, 0)",
@@ -484,23 +701,23 @@
       "fill": 6,
       "grid": {},
       "gridPos": {
-        "h": 7,
-        "w": 16,
+        "h": 4,
+        "w": 24,
         "x": 0,
-        "y": 15
+        "y": 24
       },
       "id": 47,
       "legend": {
-        "alignAsTable": false,
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "hideEmpty": false,
         "hideZero": false,
         "max": false,
         "min": false,
-        "rightSide": false,
+        "rightSide": true,
         "show": true,
-        "sideWidth": null,
+        "sideWidth": 250,
         "sort": "max",
         "sortDesc": true,
         "total": false,
@@ -600,91 +817,186 @@
       }
     },
     {
-      "columns": [
-        {
-          "text": "Current",
-          "value": "current"
-        },
-        {
-          "text": "Avg",
-          "value": "avg"
-        },
-        {
-          "text": "Max",
-          "value": "max"
-        }
-      ],
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fontSize": "90%",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 15
-      },
-      "hideTimeOverride": false,
-      "id": 48,
-      "links": [],
-      "pageSize": null,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": null,
-        "desc": false
-      },
-      "styles": [
-        {
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 2,
-          "pattern": ".*",
-          "thresholds": [],
-          "type": "number",
-          "unit": "percent"
-        }
-      ],
-      "targets": [
-        {
-          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"5.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "5xx",
-          "refId": "A",
-          "step": 240
-        },
-        {
-          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"4.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "4xx",
-          "refId": "B",
-          "step": 240
-        }
-      ],
-      "title": "HTTP Error Rate (sum): $node",
-      "transform": "timeseries_aggregations",
-      "type": "table"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 28
       },
       "id": 36,
       "panels": [],
       "title": "Upstream",
       "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1-5s": "rgb(0, 0, 255)",
+        "1s-5s": "rgb(255, 113, 0)",
+        "200ms-1s": "rgb(255, 255, 0)",
+        "40ms-200ms": "rgb(0, 0, 255)",
+        "5-25s": "rgb(255, 125, 0)",
+        "5s-25s": "rgb(162, 63, 63)",
+        "8ms-40ms": "rgb(0, 120, 0)",
+        "<200ms": "rgb(255, 0, 255)",
+        "<8ms": "rgb(0, 255, 0)",
+        ">25s": "rgb(255, 25, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 49,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 250,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "dashboard": "Admin Router Details Upstream Latency",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "Admin Router Details Upstream Latency",
+          "type": "dashboard",
+          "url": "/service/monitoring/grafana/d/ywywalsduacd/admin-router-details-upstream-latency"
+        }
+      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "node",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": ">25s",
+          "refId": "C"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "5s-25s",
+          "refId": "B"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "1s-5s",
+          "refId": "A"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "200ms-1s",
+          "refId": "E"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "40ms-200ms",
+          "refId": "D"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "8ms-40ms",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "<8ms",
+          "refId": "G"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Upstream HTTP Latency: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log Percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -698,10 +1010,10 @@
       "fill": 4,
       "grid": {},
       "gridPos": {
-        "h": 12,
+        "h": 13,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 34
       },
       "id": 22,
       "legend": {
@@ -714,7 +1026,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 270,
+        "sideWidth": 250,
         "sort": "max",
         "sortDesc": true,
         "total": false,
@@ -822,12 +1134,12 @@
       "fill": 6,
       "grid": {},
       "gridPos": {
-        "h": 7,
+        "h": 4,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 47
       },
-      "id": 49,
+      "id": 57,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -838,7 +1150,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sideWidth": 270,
+        "sideWidth": 250,
         "sort": "max",
         "sortDesc": true,
         "total": false,
@@ -1066,5 +1378,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Traffic",
   "uid": "adminrouter-details-traffic",
-  "version": 9
+  "version": 26
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
@@ -53,7 +53,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1553873014443,
+  "iteration": 1554286957587,
   "links": [
     {
       "icon": "external link",
@@ -150,12 +150,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "Admin Router Details Server Status",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Server Status",
+          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/adminrouter-details-server-status/admin-router-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -331,12 +331,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "Admin Router Details Server Status",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Server Status",
+          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/adminrouter-details-server-status/admin-router-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -510,12 +510,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "Admin Router Details Server Status",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Server Status",
+          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/adminrouter-details-server-status/admin-router-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -715,12 +715,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "Admin Router Details Upstream Status",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Upstream Status",
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/jkhlkjdshfsafd/admin-router-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
         }
       ],
       "nullPointMode": "null",
@@ -839,12 +839,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "Admin Router Details Upstream Status",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Upstream Status",
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/jkhlkjdshfsafd/admin-router-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
         }
       ],
       "nullPointMode": "null",
@@ -1055,7 +1055,7 @@
     ]
   },
   "timezone": "",
-  "title": "Admin Router: Details Traffic",
+  "title": "/AdminRouter/AdminRouter-Details-Traffic",
   "uid": "adminrouter-details-traffic",
-  "version": 6
+  "version": 3
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
@@ -47,7 +47,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554479976162,
+  "iteration": 1554737164099,
   "links": [
     {
       "icon": "external link",
@@ -66,6 +66,19 @@
         "dc/os",
         "summary",
         "adminrouter"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "runtime"
       ],
       "type": "dashboards"
     },
@@ -109,19 +122,6 @@
         "service"
       ],
       "title": "Service",
-      "type": "dashboards"
-    },
-    {
-      "asDropdown": false,
-      "icon": "external link",
-      "includeVars": true,
-      "keepTime": true,
-      "tags": [
-        "dc/os",
-        "detail",
-        "adminrouter",
-        "runtime"
-      ],
       "type": "dashboards"
     }
   ],
@@ -187,16 +187,7 @@
       },
       "lines": true,
       "linewidth": 1,
-      "links": [
-        {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
-          "includeVars": true,
-          "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
-          "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
-        }
-      ],
+      "links": [],
       "nullPointMode": "null",
       "percentage": false,
       "pointradius": 1,
@@ -268,7 +259,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Nginx Latency Distribution (sum): $node",
+      "title": "Nginx HTTP Request Latency Distribution (sum): $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -340,16 +331,7 @@
       },
       "lines": false,
       "linewidth": 2,
-      "links": [
-        {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
-          "includeVars": true,
-          "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
-          "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
-        }
-      ],
+      "links": [],
       "nullPointMode": "null",
       "percentage": false,
       "pointradius": 5,
@@ -361,7 +343,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host) + sum(irate(nginx_upstream_status_requests_total{upstream=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host)",
+          "expr": "sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host) + sum(irate(nginx_upstream_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -372,7 +354,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Nginx Throughput: $node",
+      "title": "Nginx HTTP Request Throughput: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -474,12 +456,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "dashboard": "AdminRouter: Details Server Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "title": "AdminRouter: Details Server Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -553,7 +535,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server Latency Distribution (sum): $node",
+      "title": "Server HTTP Request Latency Distribution (sum): $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -646,18 +628,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host) + sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host)",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,upstream) or sum(irate(nginx_service_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,upstream)) by (host)",
           "format": "time_series",
           "hide": false,
-          "intervalFactor": 2,
+          "intervalFactor": 1,
           "legendFormat": "{{host}}",
-          "refId": "A"
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server Throughput (sum): $node",
+      "title": "Server HTTP Request Throughput (sum): $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -741,12 +723,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "dashboard": "AdminRouter: Details Server Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "title": "AdminRouter: Details Server Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -791,7 +773,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server HTTP Error Rate (sum): $node",
+      "title": "Server HTTP Error Status Distribution (sum): $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -893,12 +875,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "dashboard": "AdminRouter: Details Upstream Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "title": "AdminRouter: Details Upstream Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-upstream-status"
         }
       ],
       "nullPointMode": "null",
@@ -973,7 +955,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Upstream Latency Distribution: $node",
+      "title": "Upstream HTTP Request Latency Distribution: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -1050,12 +1032,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "dashboard": "AdminRouter: Details Upstream Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "title": "AdminRouter: Details Upstream Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-upstream-status"
         }
       ],
       "nullPointMode": "null",
@@ -1089,7 +1071,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Upstream Throughput: $node",
+      "title": "Upstream HTTP Request Throughput: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -1174,12 +1156,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "dashboard": "AdminRouter: Details Upstream Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "title": "AdminRouter: Details Upstream Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-upstream-status"
         }
       ],
       "nullPointMode": "null",
@@ -1223,7 +1205,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Upstream HTTP Error Rate (sum): $node",
+      "title": "Upstream HTTP Error Status Distribution (sum): $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -1325,12 +1307,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "dashboard": "AdminRouter: Details Service Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "title": "AdminRouter: Details Service Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-status/adminrouter-details-service-status"
         }
       ],
       "nullPointMode": "null",
@@ -1404,7 +1386,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Service Latency Distribution: $node",
+      "title": "Service HTTP Request Latency Distribution: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -1481,12 +1463,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "dashboard": "AdminRouter: Details Service Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "title": "AdminRouter: Details Service Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-status/adminrouter-details-service-status"
         }
       ],
       "nullPointMode": "null",
@@ -1520,7 +1502,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Service Throughput: $node",
+      "title": "Service HTTP Request Throughput: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -1605,12 +1587,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "dashboard": "AdminRouter: Details Service Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "title": "AdminRouter: Details Service Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-status/adminrouter-details-service-status"
         }
       ],
       "nullPointMode": "null",
@@ -1654,7 +1636,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Service HTTP Error Rate (sum): $node",
+      "title": "Service HTTP Error Status Distribution (sum): $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -1712,7 +1694,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "Node",
-        "multi": false,
+        "multi": true,
         "name": "node",
         "options": [],
         "query": "label_values(nginx_vts_info{dcos_component_name=\"Admin Router\"},host)",
@@ -1821,7 +1803,7 @@
     ]
   },
   "timezone": "",
-  "title": "/AdminRouter/AdminRouter-Details-Traffic",
+  "title": "AdminRouter: Details Traffic",
   "uid": "adminrouter-details-traffic",
-  "version": 41
+  "version": 20
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
@@ -1676,7 +1676,7 @@
       }
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [

--- a/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
@@ -53,7 +53,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554286957587,
+  "iteration": 1554382292428,
   "links": [
     {
       "icon": "external link",
@@ -350,7 +350,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host)",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,upstream)) by (host)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -541,7 +541,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\".*\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_requests_total{server=~\".*\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"5.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -549,7 +549,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\".*\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_requests_total{server=~\".*\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"4.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -651,12 +651,21 @@
       ],
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{server=~\".*\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_server_status_requests_total{server=~\".*\",status=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"5.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "5xx",
           "refId": "A",
+          "step": 240
+        },
+        {
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{status=~\"4.*\",backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) / sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)) * 100",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "4xx",
+          "refId": "B",
           "step": 240
         }
       ],
@@ -743,7 +752,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_backend_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)",
+          "expr": "sum(irate(nginx_upstream_backend_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{upstream}}",
@@ -869,7 +878,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\".*\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\".+\",backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\".*\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -877,7 +886,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\".*\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\".+\",backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\".*\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1057,5 +1066,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Traffic",
   "uid": "adminrouter-details-traffic",
-  "version": 3
+  "version": 9
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
@@ -47,7 +47,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554471932059,
+  "iteration": 1554479976162,
   "links": [
     {
       "icon": "external link",
@@ -95,6 +95,20 @@
         "upstream"
       ],
       "title": "Upstream",
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "service"
+      ],
+      "title": "Service",
       "type": "dashboards"
     },
     {
@@ -879,12 +893,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "Admin Router Details Upstream Latency",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Upstream Latency",
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/ywywalsduacd/admin-router-details-upstream-latency"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
         }
       ],
       "nullPointMode": "null",
@@ -892,15 +906,15 @@
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
-      "repeat": "node",
-      "repeatDirection": "v",
+      "repeat": null,
+      "repeatDirection": "h",
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -908,7 +922,7 @@
           "refId": "C"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -916,7 +930,7 @@
           "refId": "B"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -924,7 +938,7 @@
           "refId": "A"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -932,7 +946,7 @@
           "refId": "E"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -940,7 +954,7 @@
           "refId": "D"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -948,7 +962,7 @@
           "refId": "F"
         },
         {
-          "expr": "sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -959,7 +973,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Upstream HTTP Latency: $node",
+      "title": "Upstream Latency Distribution: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -1064,7 +1078,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_backend_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{upstream}}",
@@ -1092,7 +1106,7 @@
       },
       "yaxes": [
         {
-          "decimals": null,
+          "decimals": 2,
           "format": "none",
           "label": "Requests/s",
           "logBase": 1,
@@ -1190,7 +1204,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\".+\",backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\".*\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1198,7 +1212,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\".+\",backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\".*\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1210,6 +1224,437 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Upstream HTTP Error Rate (sum): $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "percent",
+          "label": "log Percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 59,
+      "panels": [],
+      "title": "Service",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "1-5s": "rgb(0, 0, 255)",
+        "1s-5s": "rgb(255, 113, 0)",
+        "200ms-1s": "rgb(255, 255, 0)",
+        "40ms-200ms": "rgb(0, 0, 255)",
+        "5-25s": "rgb(255, 125, 0)",
+        "5s-25s": "rgb(162, 63, 63)",
+        "8ms-40ms": "rgb(0, 120, 0)",
+        "<200ms": "rgb(255, 0, 255)",
+        "<8ms": "rgb(0, 255, 0)",
+        ">25s": "rgb(255, 25, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 60,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 250,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "type": "dashboard",
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+        }
+      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": ">25s",
+          "refId": "C"
+        },
+        {
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "5s-25s",
+          "refId": "B"
+        },
+        {
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "1s-5s",
+          "refId": "A"
+        },
+        {
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "200ms-1s",
+          "refId": "E"
+        },
+        {
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "40ms-200ms",
+          "refId": "D"
+        },
+        {
+          "expr": "(sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "8ms-40ms",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_request_duration_seconds_bucket{backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "<8ms",
+          "refId": "G"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Service Latency Distribution: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log Percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fill": 4,
+      "grid": {},
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 61,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 250,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 2,
+      "links": [
+        {
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "type": "dashboard",
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+        }
+      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Live nodes",
+          "yaxis": 1
+        },
+        {
+          "alias": "All nodes",
+          "yaxis": 1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(nginx_service_status_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (service)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{service}}",
+          "refId": "C",
+          "step": 120
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Service Throughput: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": 2,
+          "format": "ms",
+          "label": "Latency",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "1xx": "rgb(255, 0, 255)",
+        "2xx": "rgb(0, 255, 0)",
+        "3xx": "rgb(0, 0, 255)",
+        "4xx": "rgb(255, 125, 0)",
+        "5xx": "rgb(255, 0, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "id": 62,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 250,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "type": "dashboard",
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+        }
+      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [
+        {
+          "alias": "5xx",
+          "fill": 10
+        },
+        {
+          "alias": "4xx",
+          "color": "#99440a",
+          "fill": 1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(nginx_service_status_requests_total{backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(irate(nginx_service_status_requests_total{backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_service_status_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Service HTTP Error Rate (sum): $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -1378,5 +1823,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Traffic",
   "uid": "adminrouter-details-traffic",
-  "version": 26
+  "version": 41
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Upstream-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Upstream-Responses.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554472119182,
+  "iteration": 1554480169575,
   "links": [
     {
       "icon": "external link",
@@ -101,6 +101,20 @@
         "upstream"
       ],
       "title": "Upstream",
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "service"
+      ],
+      "title": "Service",
       "type": "dashboards"
     },
     {
@@ -200,7 +214,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -208,7 +222,7 @@
           "refId": "C"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -216,7 +230,7 @@
           "refId": "B"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -224,7 +238,7 @@
           "refId": "A"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -232,7 +246,7 @@
           "refId": "E"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -240,7 +254,7 @@
           "refId": "D"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -248,7 +262,7 @@
           "refId": "F"
         },
         {
-          "expr": "sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",status=~\"$status\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -916,5 +930,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
   "uid": "adminrouter-details-upstream-responses",
-  "version": 30
+  "version": 35
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Upstream-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Upstream-Responses.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1553873336682,
+  "iteration": 1554287982543,
   "links": [
     {
       "icon": "external link",
@@ -174,12 +174,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "Admin Router Details Upstream Status",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Upstream Status",
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/jkhlkjdshfsafd/admin-router-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
         }
       ],
       "nullPointMode": "null",
@@ -316,12 +316,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "Admin Router Details Upstream Status",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Upstream Status",
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/jkhlkjdshfsafd/admin-router-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
         }
       ],
       "nullPointMode": "null",
@@ -603,7 +603,7 @@
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": "Upstream",
         "multi": false,
         "name": "upstream",
@@ -635,9 +635,7 @@
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "label_values(nginx_upstream_backend_requests_total{upstream=\"$tag\",dcos_component_name=\"Admin Router\"},backend)",
-        "tags": [
-          "IAM"
-        ],
+        "tags": [],
         "tagsQuery": "label_values(nginx_upstream_backend_requests_total{upstream=\"$upstream\",dcos_component_name=\"Admin Router\"},upstream)",
         "type": "query",
         "useTags": true
@@ -758,7 +756,7 @@
     ]
   },
   "timezone": "",
-  "title": "Admin Router: Details Upstream Responses",
+  "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
   "uid": "adminrouter-details-upstream-responses",
-  "version": 4
+  "version": 5
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Upstream-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Upstream-Responses.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554287982543,
+  "iteration": 1554382354420,
   "links": [
     {
       "icon": "external link",
@@ -195,7 +195,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\"$upstream\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -203,7 +203,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\"$upstream\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -211,7 +211,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\"$upstream\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -219,7 +219,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\"$upstream\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -329,6 +329,7 @@
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
+      "repeat": "backend",
       "repeatDirection": "v",
       "seriesOverrides": [
         {
@@ -350,7 +351,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status)",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -470,7 +471,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_useragent_requests_total{upstream=~\"$upstream\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,useragent)",
+          "expr": "sum(irate(nginx_upstream_useragent_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,useragent)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -552,7 +553,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_uri_requests_total{upstream=~\"$upstream\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,uri)",
+          "expr": "sum(irate(nginx_upstream_uri_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,uri)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -603,7 +604,7 @@
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
-        "includeAll": true,
+        "includeAll": false,
         "label": "Upstream",
         "multi": false,
         "name": "upstream",
@@ -635,7 +636,9 @@
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "label_values(nginx_upstream_backend_requests_total{upstream=\"$tag\",dcos_component_name=\"Admin Router\"},backend)",
-        "tags": [],
+        "tags": [
+          "IAM"
+        ],
         "tagsQuery": "label_values(nginx_upstream_backend_requests_total{upstream=\"$upstream\",dcos_component_name=\"Admin Router\"},upstream)",
         "type": "query",
         "useTags": true
@@ -758,5 +761,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
   "uid": "adminrouter-details-upstream-responses",
-  "version": 5
+  "version": 18
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Upstream-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Upstream-Responses.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554382354420,
+  "iteration": 1554472119182,
   "links": [
     {
       "icon": "external link",
@@ -131,6 +131,175 @@
   "panels": [
     {
       "aliasColors": {
+        "1-5s": "rgb(0, 0, 255)",
+        "1s-5s": "rgb(255, 113, 0)",
+        "200ms-1s": "rgb(255, 255, 0)",
+        "40ms-200ms": "rgb(0, 0, 255)",
+        "5-25s": "rgb(255, 125, 0)",
+        "5s-25s": "rgb(162, 63, 63)",
+        "8ms-40ms": "rgb(0, 120, 0)",
+        "<200ms": "rgb(255, 0, 255)",
+        "<8ms": "rgb(0, 255, 0)",
+        ">25s": "rgb(255, 25, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 52,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 120,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "type": "dashboard",
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+        }
+      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "node",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": ">25s",
+          "refId": "C"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "5s-25s",
+          "refId": "B"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "1s-5s",
+          "refId": "A"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "200ms-1s",
+          "refId": "E"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "40ms-200ms",
+          "refId": "D"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "8ms-40ms",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\"$backend\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "<8ms",
+          "refId": "G"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Upstream HTTP Latency: $upstream ($backend)",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log Percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
         "1xx": "rgb(255, 0, 255)",
         "2xx": "rgb(0, 255, 0)",
         "3xx": "rgb(0, 0, 255)",
@@ -148,10 +317,10 @@
       "fill": 6,
       "grid": {},
       "gridPos": {
-        "h": 7,
+        "h": 5,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 5
       },
       "id": 49,
       "legend": {
@@ -195,7 +364,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -203,7 +372,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -211,7 +380,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -219,7 +388,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -290,10 +459,10 @@
       "fill": 6,
       "grid": {},
       "gridPos": {
-        "h": 7,
+        "h": 6,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 10
       },
       "id": 51,
       "legend": {
@@ -331,21 +500,7 @@
       "renderer": "flot",
       "repeat": "backend",
       "repeatDirection": "v",
-      "seriesOverrides": [
-        {
-          "alias": "Latency",
-          "bars": false,
-          "fill": 0,
-          "linewidth": 1,
-          "stack": false,
-          "yaxis": 2
-        },
-        {
-          "alias": "total",
-          "stack": false,
-          "zindex": -3
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": true,
       "steppedLine": false,
@@ -412,10 +567,10 @@
       "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 16
       },
       "id": 47,
       "links": [],
@@ -471,7 +626,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_useragent_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,useragent)",
+          "expr": "sum(irate(nginx_upstream_useragent_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,useragent)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -493,10 +648,10 @@
       "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 14
+        "y": 16
       },
       "id": 45,
       "links": [],
@@ -553,7 +708,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_uri_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,uri)",
+          "expr": "sum(irate(nginx_upstream_uri_requests_total{upstream=~\"$upstream\",backend=~\"$backend\",status=~\"$status\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (status,uri)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -761,5 +916,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
   "uid": "adminrouter-details-upstream-responses",
-  "version": 18
+  "version": 30
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Upstream-Status.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Upstream-Status.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554287840719,
+  "iteration": 1554382368928,
   "links": [
     {
       "icon": "external link",
@@ -323,7 +323,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\"$upstream\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"5.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -331,7 +331,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\"$upstream\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"4.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -339,7 +339,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\"$upstream\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"3.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -347,7 +347,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_requests_total{upstream=~\"$upstream\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"2.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -355,7 +355,7 @@
           "refId": "E"
         },
         {
-          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",status=~\"1.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(rate(nginx_upstream_backend_requests_total{upstream=~\"$upstream\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",status=~\"1.*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(rate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "D"
@@ -576,5 +576,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
   "uid": "adminrouter-details-upstream-status",
-  "version": 2
+  "version": 8
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Upstream-Status.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Upstream-Status.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554472077176,
+  "iteration": 1554480193387,
   "links": [
     {
       "icon": "external link",
@@ -95,6 +95,20 @@
         "upstream"
       ],
       "title": "Upstream",
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "service"
+      ],
+      "title": "Service",
       "type": "dashboards"
     },
     {
@@ -206,7 +220,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(nginx_upstream_backend_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{upstream=~\"$upstream\",backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -328,7 +342,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -336,7 +350,7 @@
           "refId": "C"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -344,7 +358,7 @@
           "refId": "B"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -352,7 +366,7 @@
           "refId": "A"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -360,7 +374,7 @@
           "refId": "E"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -368,7 +382,7 @@
           "refId": "D"
         },
         {
-          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "(sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -376,7 +390,7 @@
           "refId": "F"
         },
         {
-          "expr": "sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "expr": "sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_status_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -745,5 +759,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
   "uid": "adminrouter-details-upstream-status",
-  "version": 28
+  "version": 33
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Upstream-Status.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Upstream-Status.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554382368928,
+  "iteration": 1554472077176,
   "links": [
     {
       "icon": "external link",
@@ -159,7 +159,7 @@
       "grid": {},
       "gridPos": {
         "h": 4,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 1
       },
@@ -259,6 +259,175 @@
     },
     {
       "aliasColors": {
+        "1-5s": "rgb(0, 0, 255)",
+        "1s-5s": "rgb(255, 113, 0)",
+        "200ms-1s": "rgb(255, 255, 0)",
+        "40ms-200ms": "rgb(0, 0, 255)",
+        "5-25s": "rgb(255, 125, 0)",
+        "5s-25s": "rgb(162, 63, 63)",
+        "8ms-40ms": "rgb(0, 120, 0)",
+        "<200ms": "rgb(255, 0, 255)",
+        "<8ms": "rgb(0, 255, 0)",
+        ">25s": "rgb(255, 25, 0)",
+        "Latency": "#fce2de"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "editable": true,
+      "error": false,
+      "fill": 6,
+      "grid": {},
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 61,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 100,
+        "sort": null,
+        "sortDesc": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
+          "type": "dashboard",
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-adminrouter-details-upstream-responses"
+        }
+      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "node",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": ">25s",
+          "refId": "C"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"25\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "5s-25s",
+          "refId": "B"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"5\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "1s-5s",
+          "refId": "A"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"1\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "200ms-1s",
+          "refId": "E"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.2\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "40ms-200ms",
+          "refId": "D"
+        },
+        {
+          "expr": "(sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.04\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval]))-sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])))/sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "8ms-40ms",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",backend=~\".+\",le=\"0.008\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) / sum(irate(nginx_upstream_backend_request_duration_seconds_bucket{upstream=~\"$upstream\",backend=~\".+\",le=\"+Inf\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) * 100",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "<8ms",
+          "refId": "G"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Upstream HTTP Latency: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percent",
+          "label": "log Percent",
+          "logBase": 10,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "",
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
         "1xx": "rgb(255, 0, 255)",
         "2xx": "rgb(0, 255, 0)",
         "3xx": "rgb(0, 0, 255)",
@@ -277,8 +446,8 @@
       "grid": {},
       "gridPos": {
         "h": 4,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 1
       },
       "id": 59,
@@ -576,5 +745,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
   "uid": "adminrouter-details-upstream-status",
-  "version": 8
+  "version": 28
 }

--- a/dashboards/AdminRouter/AdminRouter-Details-Upstream-Status.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Upstream-Status.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1553873683825,
+  "iteration": 1554287840719,
   "links": [
     {
       "icon": "external link",
@@ -184,13 +184,13 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "Admin Router Details Traffic",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
           "includeVars": true,
           "keepTime": true,
           "targetBlank": false,
-          "title": "Admin Router Details Traffic",
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/whydwencsd/admin-router-details-traffic"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-adminrouter-details-upstream-responses"
         }
       ],
       "nullPointMode": "null",
@@ -302,12 +302,12 @@
       "linewidth": 1,
       "links": [
         {
-          "dashboard": "Admin Router Details Upstream Responses",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Upstream Responses",
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Responses",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/ywywalsduacd/admin-router-details-upstream-responses"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-adminrouter-details-upstream-responses"
         }
       ],
       "nullPointMode": "null",
@@ -574,7 +574,7 @@
     ]
   },
   "timezone": "",
-  "title": "Admin Router: Details Upstream Status",
+  "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
   "uid": "adminrouter-details-upstream-status",
-  "version": 3
+  "version": 2
 }

--- a/dashboards/AdminRouter/AdminRouter-Summary.json
+++ b/dashboards/AdminRouter/AdminRouter-Summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1553871437837,
+  "iteration": 1554286729218,
   "links": [
     {
       "icon": "external link",
@@ -152,12 +152,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "Admin Router Details Runtime",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Runtime",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Runtime",
+          "title": "/AdminRouter/AdminRouter-Details-Runtime",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/iuoewqiuyrowqer/admin-router-details-runtime"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-runtime/adminrouter-adminrouter-details-runtime"
         }
       ],
       "nullPointMode": "null",
@@ -276,12 +276,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "Admin Router Details Runtime",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Runtime",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Runtime",
+          "title": "/AdminRouter/AdminRouter-Details-Runtime",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/iuoewqiuyrowqer/admin-router-details-runtime"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-runtime/adminrouter-adminrouter-details-runtime"
         }
       ],
       "nullPointMode": "null",
@@ -401,12 +401,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "Admin Router Details Runtime",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Runtime",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Runtime",
+          "title": "/AdminRouter/AdminRouter-Details-Runtime",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/iuoewqiuyrowqer/admin-router-details-runtime"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-runtime/adminrouter-adminrouter-details-runtime"
         }
       ],
       "nullPointMode": "null",
@@ -515,12 +515,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "Admin Router Details Server Status",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Server Status",
+          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/adminrouter-details-server-status/admin-router-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -632,12 +632,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "Admin Router Details Server Status",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Server Status",
+          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/adminrouter-details-server-status/admin-router-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -753,12 +753,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "Admin Router Details Upstream Status",
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "Admin Router Details Upstream Status",
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
           "type": "dashboard",
-          "url": "/service/monitoring/grafana/d/jkhlkjdshfsafd/admin-router-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
         }
       ],
       "nullPointMode": "null",
@@ -973,7 +973,7 @@
     ]
   },
   "timezone": "",
-  "title": "Admin Router: Summary",
+  "title": "/AdminRouter/AdminRouter-Summary",
   "uid": "adminrouter-summary",
-  "version": 14
+  "version": 3
 }

--- a/dashboards/AdminRouter/AdminRouter-Summary.json
+++ b/dashboards/AdminRouter/AdminRouter-Summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554382250120,
+  "iteration": 1554471852319,
   "links": [
     {
       "icon": "external link",
@@ -847,7 +847,7 @@
       "type": "text"
     }
   ],
-  "refresh": "5s",
+  "refresh": false,
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
@@ -975,5 +975,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Summary",
   "uid": "adminrouter-summary",
-  "version": 9
+  "version": 11
 }

--- a/dashboards/AdminRouter/AdminRouter-Summary.json
+++ b/dashboards/AdminRouter/AdminRouter-Summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554286729218,
+  "iteration": 1554382250120,
   "links": [
     {
       "icon": "external link",
@@ -651,7 +651,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host)",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,upstream)) by (host)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -727,27 +727,27 @@
       "fill": 4,
       "grid": {},
       "gridPos": {
-        "h": 10,
+        "h": 7,
         "w": 16,
         "x": 0,
         "y": 35
       },
       "id": 36,
       "legend": {
-        "alignAsTable": true,
+        "alignAsTable": false,
         "avg": false,
         "current": false,
         "hideEmpty": false,
         "hideZero": false,
-        "max": true,
+        "max": false,
         "min": false,
-        "rightSide": true,
+        "rightSide": false,
         "show": true,
         "sideWidth": 270,
         "sort": "max",
         "sortDesc": true,
         "total": false,
-        "values": true
+        "values": false
       },
       "lines": false,
       "linewidth": 2,
@@ -781,7 +781,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_backend_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)",
+          "expr": "sum(irate(nginx_upstream_backend_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{upstream}}",
@@ -835,7 +835,7 @@
     {
       "content": "Stacked upstream throughput measured as requests per second going to each upstream server aggregated over all master nodes. This graph helps to identify upstreams that are particularly active.",
       "gridPos": {
-        "h": 10,
+        "h": 7,
         "w": 8,
         "x": 16,
         "y": 35
@@ -975,5 +975,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Summary",
   "uid": "adminrouter-summary",
-  "version": 3
+  "version": 9
 }

--- a/dashboards/AdminRouter/AdminRouter-Summary.json
+++ b/dashboards/AdminRouter/AdminRouter-Summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554471852319,
+  "iteration": 1554479930799,
   "links": [
     {
       "icon": "external link",
@@ -90,6 +90,20 @@
         "upstream"
       ],
       "title": "Upstream",
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "service"
+      ],
+      "title": "Service",
       "type": "dashboards"
     },
     {
@@ -534,7 +548,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host) + sum(irate(nginx_upstream_status_requests_total{upstream=~\".*\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host)",
+          "expr": "sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host) + sum(irate(nginx_upstream_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host) + sum(irate(nginx_service_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -781,7 +795,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(nginx_upstream_backend_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)",
+          "expr": "sum(irate(nginx_upstream_status_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (upstream)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{upstream}}",
@@ -845,9 +859,140 @@
       "mode": "markdown",
       "title": "Admin Router Upstream Throughput",
       "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fill": 4,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 42
+      },
+      "id": 39,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 270,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 2,
+      "links": [
+        {
+          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "includeVars": true,
+          "keepTime": true,
+          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "type": "dashboard",
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+        }
+      ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Live nodes",
+          "yaxis": 1
+        },
+        {
+          "alias": "All nodes",
+          "yaxis": 1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(nginx_service_status_requests_total{backend=~\".+\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (service)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{service}}",
+          "refId": "C",
+          "step": 120
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Service Throughput: $node",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "none",
+          "label": "Requests/s",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": 2,
+          "format": "ms",
+          "label": "Latency",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "Stacked service throughput measured as requests per second going to each service upstream server aggregated over all master nodes. This graph helps to identify services that are particularly active.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 42
+      },
+      "id": 40,
+      "links": [],
+      "mode": "markdown",
+      "title": "Admin Router Service Throughput",
+      "type": "text"
     }
   ],
-  "refresh": false,
+  "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
@@ -975,5 +1120,5 @@
   "timezone": "",
   "title": "/AdminRouter/AdminRouter-Summary",
   "uid": "adminrouter-summary",
-  "version": 11
+  "version": 15
 }

--- a/dashboards/AdminRouter/AdminRouter-Summary.json
+++ b/dashboards/AdminRouter/AdminRouter-Summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554479930799,
+  "iteration": 1554737020216,
   "links": [
     {
       "icon": "external link",
@@ -62,6 +62,32 @@
         "dc/os",
         "overview"
       ],
+      "type": "dashboards"
+    },
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "runtime"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "dc/os",
+        "detail",
+        "adminrouter",
+        "traffic"
+      ],
+      "title": "",
       "type": "dashboards"
     },
     {
@@ -105,32 +131,6 @@
       ],
       "title": "Service",
       "type": "dashboards"
-    },
-    {
-      "asDropdown": false,
-      "icon": "external link",
-      "includeVars": true,
-      "keepTime": true,
-      "tags": [
-        "dc/os",
-        "detail",
-        "adminrouter",
-        "traffic"
-      ],
-      "title": "Admin Router Details",
-      "type": "dashboards"
-    },
-    {
-      "icon": "external link",
-      "includeVars": true,
-      "keepTime": true,
-      "tags": [
-        "dc/os",
-        "detail",
-        "adminrouter",
-        "runtime"
-      ],
-      "type": "dashboards"
     }
   ],
   "panels": [
@@ -166,12 +166,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Runtime",
+          "dashboard": "AdminRouter: Details Runtime",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Runtime",
+          "title": "AdminRouter: Details Runtime",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-runtime/adminrouter-adminrouter-details-runtime"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-runtime/adminrouter-details-runtime"
         }
       ],
       "nullPointMode": "null",
@@ -290,12 +290,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Runtime",
+          "dashboard": "AdminRouter: Details Runtime",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Runtime",
+          "title": "AdminRouter: Details Runtime",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-runtime/adminrouter-adminrouter-details-runtime"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-runtime/adminrouter-details-runtime"
         }
       ],
       "nullPointMode": "null",
@@ -529,12 +529,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "dashboard": "AdminRouter: Details Traffic",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "title": "AdminRouter: Details Traffic",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-traffic/adminrouter-details-traffic"
         }
       ],
       "nullPointMode": "null",
@@ -559,7 +559,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Nginx Throughput: $node",
+      "title": "Nginx HTTP Request Throughput: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -609,7 +609,7 @@
       "id": 30,
       "links": [],
       "mode": "markdown",
-      "title": "Admin Router Nginx Throughput",
+      "title": "Admin Router Nginx HTTP Request Throughput",
       "type": "text"
     },
     {
@@ -646,12 +646,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "dashboard": "AdminRouter: Details Server Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Server-Status",
+          "title": "AdminRouter: Details Server Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-adminrouter-details-server-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -665,7 +665,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,upstream)) by (host)",
+          "expr": "sum(sum(irate(nginx_server_status_requests_total{dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,server) or sum(irate(nginx_upstream_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,upstream) or sum(irate(nginx_service_status_requests_total{backend=\"\",dcos_component_name=\"Admin Router\",host=~\"$node\"}[$rate_interval])) by (host,upstream)) by (host)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -676,7 +676,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Server Throughput: $node",
+      "title": "Server HTTP Request Throughput: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -726,7 +726,7 @@
       "id": 38,
       "links": [],
       "mode": "markdown",
-      "title": "Admin Router Server Throughput",
+      "title": "Admin Router Server HTTP Request Throughput",
       "type": "text"
     },
     {
@@ -767,12 +767,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "dashboard": "AdminRouter: Details Upstream Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "title": "AdminRouter: Details Upstream Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-upstream-status"
         }
       ],
       "nullPointMode": "null",
@@ -806,7 +806,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Upstream Throughput: $node",
+      "title": "Upstream HTTP Request Throughput: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -857,7 +857,7 @@
       "id": 20,
       "links": [],
       "mode": "markdown",
-      "title": "Admin Router Upstream Throughput",
+      "title": "Admin Router Upstream HTTP Request Throughput",
       "type": "text"
     },
     {
@@ -898,12 +898,12 @@
       "linewidth": 2,
       "links": [
         {
-          "dashboard": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "dashboard": "AdminRouter: Details Service Status",
           "includeVars": true,
           "keepTime": true,
-          "title": "/AdminRouter/AdminRouter-Details-Upstream-Status",
+          "title": "AdminRouter: Details Service Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-adminrouter-details-upstream-status"
+          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-status/adminrouter-details-service-status"
         }
       ],
       "nullPointMode": "null",
@@ -937,7 +937,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Service Throughput: $node",
+      "title": "Service HTTP Request Throughput: $node",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -988,11 +988,11 @@
       "id": 40,
       "links": [],
       "mode": "markdown",
-      "title": "Admin Router Service Throughput",
+      "title": "Admin Router Service HTTP Request Throughput",
       "type": "text"
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
@@ -1118,7 +1118,7 @@
     ]
   },
   "timezone": "",
-  "title": "/AdminRouter/AdminRouter-Summary",
+  "title": "AdminRouter: Summary",
   "uid": "adminrouter-summary",
-  "version": 15
+  "version": 9
 }


### PR DESCRIPTION
This PR adds a number of things we have been working on for Admin Router dashboards:

1. [DCOS_OSS-4972](https://jira.mesosphere.com/browse/DCOS_OSS-4972) Fix Admin Router dashboard linking for previously existing dashboards/graphs
2. [DCOS-51189](https://jira.mesosphere.com/browse/DCOS-51189) Count access denied (401 Unauthorized) on the server level
3. [DCOS_OSS-4665](https://jira.mesosphere.com/browse/DCOS_OSS-4665) Add latency histogram data graphs for all requests 
4. [DCOS_OSS-5015](https://jira.mesosphere.com/browse/DCOS_OSS-5015) Add dedicated dashboards for DC/OS services accessed through Admin Router