### PR TITLE
Prettify and fix wrong labels

### DIFF
--- a/dashboards/ZooKeeper-Summary.json
+++ b/dashboards/ZooKeeper-Summary.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1554278472077,
+  "iteration": 1554889230168,
   "links": [
     {
       "icon": "external link",
@@ -78,6 +78,259 @@
   ],
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 79,
+      "panels": [],
+      "title": "Exhibitor: ZooKeeper Instance Status",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 3,
+        "w": 16,
+        "x": 0,
+        "y": 1
+      },
+      "id": 48,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "node",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "exhibitor_status_code{dcos_component_name=\"Exhibitor\",host=~\"$node\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{exhibitor_address}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "ZooKeeper Instance Status: $node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": "3",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "This graph helps to identify the current exhibitor status of the cluster. The status code indicates the run level of each Exhibitor instance. Healthy Exhibitor instances are in `serving` state.\n\n| Status code | Meaning |\n|---|---|\n| 3 | Serving |\n| 2 | Not serving |\n| 1 | Down |\n| 0 | Latent |",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 49,
+      "links": [],
+      "mode": "markdown",
+      "repeat": null,
+      "repeatDirection": "v",
+      "title": "ZooKeeper Instance Status",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 85,
+      "panels": [],
+      "title": "Exhibitor: ZooKeeper Leader Opinion",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 3,
+        "w": 16,
+        "x": 0,
+        "y": 11
+      },
+      "id": 50,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "node",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(exhibitor_status_isleader{dcos_component_name=\"Exhibitor\",host=~\"$node\",exhibitor_address=~\".*\"} > 0) by (exhibitor_address)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{exhibitor_address}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "ZooKeeper Leader Opinion: $node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": "1",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "These graphs shows the current ZooKeeper leader opinion of Exhibitor the instances over time.\n\n| Status | Meaning |\n|---|---|\n| 1 | Leader |",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 11
+      },
+      "id": 55,
+      "links": [],
+      "mode": "markdown",
+      "repeat": null,
+      "repeatDirection": "v",
+      "title": "ZooKeeper Leader Opinion",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 67,
+      "panels": [],
+      "title": "ZooKeeper",
+      "type": "row"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -88,7 +341,7 @@
         "h": 7,
         "w": 16,
         "x": 0,
-        "y": 0
+        "y": 21
       },
       "id": 16,
       "legend": {
@@ -172,7 +425,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 0
+        "y": 21
       },
       "id": 14,
       "links": [],
@@ -191,7 +444,7 @@
         "h": 7,
         "w": 16,
         "x": 0,
-        "y": 7
+        "y": 28
       },
       "id": 22,
       "legend": {
@@ -271,7 +524,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 7
+        "y": 28
       },
       "id": 39,
       "links": [],
@@ -290,7 +543,7 @@
         "h": 7,
         "w": 16,
         "x": 0,
-        "y": 14
+        "y": 35
       },
       "id": 38,
       "legend": {
@@ -374,7 +627,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 14
+        "y": 35
       },
       "id": 47,
       "links": [],
@@ -393,7 +646,7 @@
         "h": 7,
         "w": 16,
         "x": 0,
-        "y": 21
+        "y": 42
       },
       "id": 28,
       "legend": {
@@ -477,7 +730,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 21
+        "y": 42
       },
       "id": 40,
       "links": [],
@@ -496,7 +749,7 @@
         "h": 7,
         "w": 16,
         "x": 0,
-        "y": 28
+        "y": 49
       },
       "id": 34,
       "legend": {
@@ -580,7 +833,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 28
+        "y": 49
       },
       "id": 41,
       "links": [],
@@ -599,7 +852,7 @@
         "h": 7,
         "w": 16,
         "x": 0,
-        "y": 35
+        "y": 56
       },
       "id": 30,
       "legend": {
@@ -683,7 +936,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 35
+        "y": 56
       },
       "id": 46,
       "links": [],
@@ -702,7 +955,7 @@
         "h": 7,
         "w": 16,
         "x": 0,
-        "y": 42
+        "y": 63
       },
       "id": 26,
       "legend": {
@@ -786,7 +1039,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 42
+        "y": 63
       },
       "id": 42,
       "links": [],
@@ -805,7 +1058,7 @@
         "h": 7,
         "w": 16,
         "x": 0,
-        "y": 49
+        "y": 70
       },
       "id": 24,
       "legend": {
@@ -885,7 +1138,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 49
+        "y": 70
       },
       "id": 43,
       "links": [],
@@ -904,7 +1157,7 @@
         "h": 7,
         "w": 16,
         "x": 0,
-        "y": 56
+        "y": 77
       },
       "id": 36,
       "legend": {
@@ -988,7 +1241,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 56
+        "y": 77
       },
       "id": 44,
       "links": [],
@@ -1007,7 +1260,7 @@
         "h": 7,
         "w": 16,
         "x": 0,
-        "y": 63
+        "y": 84
       },
       "id": 12,
       "legend": {
@@ -1091,263 +1344,12 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 63
+        "y": 84
       },
       "id": 45,
       "links": [],
       "mode": "markdown",
       "title": "ZooKeeper Packet Receive Rate",
-      "type": "text"
-    },
-    {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 70
-      },
-      "id": 65,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 16,
-            "x": 0,
-            "y": 71
-          },
-          "id": 48,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "scopedVars": {
-            "node": {
-              "selected": false,
-              "text": "dcos-e2e-default-bc32d-master-0",
-              "value": "dcos-e2e-default-bc32d-master-0"
-            }
-          },
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "exhibitor_status_code{dcos_component_name=\"Exhibitor\",host=~\"$node\"}",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{host}}",
-              "refId": "A",
-              "step": 2
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Exhibitor Node Status: $node",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "none",
-              "label": "",
-              "logBase": 1,
-              "max": "3",
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "content": "This graph helps to identify the current exhibitor status of the cluster.\n\nThe status code indicates the run level of each Exhibitor instance.\n\n| Status code | Meaning |\n|---|---|\n| 3 | Serving |\n| 2 | Not serving |\n| 1 | Down |\n| 0 | Latent |\n\nHealthy Exhibitor instances are in `serving` state.",
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 16,
-            "y": 71
-          },
-          "id": 49,
-          "links": [],
-          "mode": "markdown",
-          "scopedVars": {
-            "node": {
-              "selected": false,
-              "text": "dcos-e2e-default-bc32d-master-0",
-              "value": "dcos-e2e-default-bc32d-master-0"
-            }
-          },
-          "title": "Exhibitor node status",
-          "type": "text"
-        }
-      ],
-      "repeat": "node",
-      "title": "Exhibitor node status",
-      "type": "row"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 71
-      },
-      "id": 54,
-      "panels": [],
-      "repeat": "node",
-      "title": "Exhibitor leader opinion",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 16,
-        "x": 0,
-        "y": 72
-      },
-      "id": 50,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "repeat": null,
-      "repeatDirection": "h",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(exhibitor_status_isleader{dcos_component_name=\"Exhibitor\",host=~\"$node\",exhibitor_address=~\".*\"} > 0) by (exhibitor_address)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{exhibitor_address}}",
-          "refId": "A",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Exhibitor Leader Opinion: $node",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": 0,
-          "format": "none",
-          "label": "",
-          "logBase": 1,
-          "max": "3",
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "content": "This graph shows the current leader opinion of $node",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 72
-      },
-      "id": 55,
-      "links": [],
-      "mode": "markdown",
-      "title": "Exhibitor leader opinion of $node",
       "type": "text"
     }
   ],
@@ -1480,5 +1482,5 @@
   "timezone": "utc",
   "title": "ZooKeeper: Summary",
   "uid": "M_b16TYiz",
-  "version": 3
+  "version": 8
 }


### PR DESCRIPTION
This PR puts the ZooKeeper instance state and leader election into the focus.
It also fixes a minor bug which labelled the instance state graph wrongly.