### PR TITLE
Report correct used storage capacity

### DIFF
--- a/dashboards/CockroachDB/CockroachDB-Details-Storage.json
+++ b/dashboards/CockroachDB/CockroachDB-Details-Storage.json
@@ -142,23 +142,41 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(sum(capacity{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host)) - sum(sum(capacity_available{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
+          "expr": "sum(sum(capacity{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
           "format": "time_series",
+          "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "Used",
+          "legendFormat": "Capacity",
           "refId": "A",
           "step": 2
         },
         {
-          "expr": "sum(sum(capacity{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
+          "expr": "sum(sum(capacity_available{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
           "format": "time_series",
+          "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "Total",
+          "legendFormat": "Available",
           "metric": "",
           "refId": "B",
           "step": 2
+        },
+        {
+          "expr": "sum(sum(capacity_used{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Used",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(sum(capacity_reserved{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Reserved",
+          "refId": "F"
         }
       ],
       "thresholds": [],

--- a/dashboards/CockroachDB/CockroachDB-Summary.json
+++ b/dashboards/CockroachDB/CockroachDB-Summary.json
@@ -456,23 +456,41 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(sum(capacity{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host)) - sum(sum(capacity_available{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
+          "expr": "sum(sum(capacity{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
           "format": "time_series",
+          "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "Used",
+          "legendFormat": "Capacity",
           "refId": "A",
           "step": 2
         },
         {
-          "expr": "sum(sum(capacity{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
+          "expr": "sum(sum(capacity_available{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
           "format": "time_series",
+          "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "Total",
+          "legendFormat": "Available",
           "metric": "",
           "refId": "B",
           "step": 2
+        },
+        {
+          "expr": "sum(sum(capacity_used{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Used",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(sum(capacity_reserved{dcos_component_name=\"CockroachDB\",host=~\"$node\"}) by (host))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "Reserved",
+          "refId": "F"
         }
       ],
       "thresholds": [],


### PR DESCRIPTION
The official Grafana labs dashboards from CockroachLabs report storage capacity different from the CockroachDB UI. This seems to be a bug and is fixed in our dashboards with this PR.