### PR TITLE
zookeeper: don't use statix y axis limits

### DIFF
--- a/dashboards/ZooKeeper-Summary.json
+++ b/dashboards/ZooKeeper-Summary.json
@@ -401,7 +401,7 @@
           "format": "none",
           "label": "Ticks",
           "logBase": 1,
-          "max": "10",
+          "max": null,
           "min": "0",
           "show": true
         },
@@ -500,7 +500,7 @@
           "format": "none",
           "label": null,
           "logBase": 1,
-          "max": "10",
+          "max": null,
           "min": "0",
           "show": true
         },
@@ -603,7 +603,7 @@
           "format": "none",
           "label": "",
           "logBase": 1,
-          "max": "10",
+          "max": null,
           "min": "0",
           "show": true
         },


### PR DESCRIPTION
For failure cases certain metric values are expected
to be much greater than 10, and in these cases this
is exactly what we want to see in the dashboard.
Let Grafana dynamically adjust the y axis limits based
on the values.



For example, if the number of times a ZK fsync operation exceeded the timing threshold is more than 10 then the graph wouldn't show it. This patch is a pragmatic improvement. In addition to that I think we might want to have a logarithmic scale here and there, too.