### PR TITLE
Relative linking for Admin Router dashboards

### DIFF
--- a/dashboards/AdminRouter/AdminRouter-Details-DCOS-Component-Proxy-Individual.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-DCOS-Component-Proxy-Individual.json
@@ -203,7 +203,7 @@
           "targetBlank": false,
           "title": "Show $upstream on this DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-dc-os-component-proxy-responses"
+          "url": "d/adminrouter-details-upstream-responses/adminrouter-details-dc-os-component-proxy-responses"
         }
       ],
       "nullPointMode": "null",
@@ -311,7 +311,7 @@
           "keepTime": true,
           "title": "Show $upstream on this DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-dc-os-component-proxy-responses"
+          "url": "d/adminrouter-details-upstream-responses/adminrouter-details-dc-os-component-proxy-responses"
         }
       ],
       "nullPointMode": "null",
@@ -497,7 +497,7 @@
           "keepTime": true,
           "title": "Show $upstream on this DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-responses/adminrouter-details-dc-os-component-proxy-responses"
+          "url": "d/adminrouter-details-upstream-responses/adminrouter-details-dc-os-component-proxy-responses"
         }
       ],
       "nullPointMode": "null",

--- a/dashboards/AdminRouter/AdminRouter-Details-DCOS-Component-Proxy-Overview.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-DCOS-Component-Proxy-Overview.json
@@ -204,7 +204,7 @@
           "targetBlank": false,
           "title": "Show $upstream per DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
+          "url": "d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
         }
       ],
       "nullPointMode": "null",
@@ -314,7 +314,7 @@
           "keepTime": true,
           "title": "Show $upstream per DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
+          "url": "d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
         }
       ],
       "nullPointMode": "null",
@@ -500,7 +500,7 @@
           "keepTime": true,
           "title": "Show $upstream per DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
+          "url": "d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
         }
       ],
       "nullPointMode": "null",

--- a/dashboards/AdminRouter/AdminRouter-Details-DCOS-Component-Proxy-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-DCOS-Component-Proxy-Responses.json
@@ -184,7 +184,7 @@
           "keepTime": true,
           "title": "Show $upstream over all DC/OS Master Nodes",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
+          "url": "d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
         }
       ],
       "nullPointMode": "null",
@@ -361,7 +361,7 @@
           "dashboard": "Admin Router: Details DC/OS Component Proxy Individual",
           "title": "Show $upstream over all DC/OS Master Nodes",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
+          "url": "d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
         }
       ],
       "nullPointMode": "null",
@@ -513,7 +513,7 @@
           "keepTime": true,
           "title": "Show $upstream over all DC/OS Master Nodes",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
+          "url": "d/adminrouter-details-upstream-status/adminrouter-details-dc-os-component-proxy-individual"
         }
       ],
       "nullPointMode": "null",

--- a/dashboards/AdminRouter/AdminRouter-Details-DCOS-Service-Proxy-Individual.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-DCOS-Service-Proxy-Individual.json
@@ -204,7 +204,7 @@
           "targetBlank": false,
           "title": "Show $service on this DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-responses/adminrouter-details-dc-os-service-proxy-responses"
+          "url": "d/adminrouter-details-service-responses/adminrouter-details-dc-os-service-proxy-responses"
         }
       ],
       "nullPointMode": "null",
@@ -312,7 +312,7 @@
           "keepTime": true,
           "title": "Show $service on this DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-responses/adminrouter-details-dc-os-service-proxy-responses"
+          "url": "d/adminrouter-details-service-responses/adminrouter-details-dc-os-service-proxy-responses"
         }
       ],
       "nullPointMode": "null",
@@ -496,7 +496,7 @@
           "keepTime": true,
           "title": "Show $service on this DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-responses/adminrouter-details-dc-os-service-proxy-responses"
+          "url": "d/adminrouter-details-service-responses/adminrouter-details-dc-os-service-proxy-responses"
         }
       ],
       "nullPointMode": "null",

--- a/dashboards/AdminRouter/AdminRouter-Details-DCOS-Service-Proxy-Overview.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-DCOS-Service-Proxy-Overview.json
@@ -204,7 +204,7 @@
           "targetBlank": false,
           "title": "Show $service per DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
+          "url": "d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
         }
       ],
       "nullPointMode": "null",
@@ -312,7 +312,7 @@
           "keepTime": true,
           "title": "Show $service per DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
+          "url": "d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
         }
       ],
       "nullPointMode": "null",
@@ -496,7 +496,7 @@
           "keepTime": true,
           "title": "Show $service per DC/OS Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
+          "url": "d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
         }
       ],
       "nullPointMode": "null",

--- a/dashboards/AdminRouter/AdminRouter-Details-DCOS-Service-Proxy-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-DCOS-Service-Proxy-Responses.json
@@ -184,7 +184,7 @@
           "keepTime": true,
           "title": "Show $service over all DC/OS Master Nodes",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
+          "url": "d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
         }
       ],
       "nullPointMode": "null",
@@ -367,7 +367,7 @@
           "keepTime": true,
           "title": "Show $service over all DC/OS Master Nodes",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
+          "url": "d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
         }
       ],
       "nullPointMode": "null",
@@ -525,7 +525,7 @@
           "keepTime": true,
           "title": "Show $service over all DC/OS Master Nodes",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
+          "url": "d/adminrouter-details-service-individual/adminrouter-details-dc-os-service-proxy-individual"
         }
       ],
       "nullPointMode": "null",

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Responses.json
@@ -186,7 +186,7 @@
           "keepTime": true,
           "title": "Show Requests over all DC/OS Master Nodes",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
+          "url": "d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -369,7 +369,7 @@
           "keepTime": true,
           "title": "Show Requests over all DC/OS Master Nodes",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
+          "url": "d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -527,7 +527,7 @@
           "keepTime": true,
           "title": "Show Requests over all DC/OS Master Nodes",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
+          "url": "d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
         }
       ],
       "nullPointMode": "null",

--- a/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Server-Status.json
@@ -204,7 +204,7 @@
           "targetBlank": false,
           "title": "Show Requests on this Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-details-adminrouter-server-responses"
+          "url": "d/adminrouter-details-server-responses/adminrouter-details-adminrouter-server-responses"
         }
       ],
       "nullPointMode": "null",
@@ -312,7 +312,7 @@
           "keepTime": true,
           "title": "Show Requests on this Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-details-adminrouter-server-responses"
+          "url": "d/adminrouter-details-server-responses/adminrouter-details-adminrouter-server-responses"
         }
       ],
       "nullPointMode": "null",
@@ -496,7 +496,7 @@
           "keepTime": true,
           "title": "Show Requests on this Master Node",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-responses/adminrouter-details-adminrouter-server-responses"
+          "url": "d/adminrouter-details-server-responses/adminrouter-details-adminrouter-server-responses"
         }
       ],
       "nullPointMode": "null",

--- a/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
+++ b/dashboards/AdminRouter/AdminRouter-Details-Traffic.json
@@ -476,7 +476,7 @@
           "keepTime": true,
           "title": "Admin Router: Details Admin Router Server Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
+          "url": "d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -629,7 +629,7 @@
           "keepTime": true,
           "title": "Admin Router: Details Admin Router Server Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
+          "url": "d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -734,7 +734,7 @@
           "keepTime": true,
           "title": "Admin Router: Details Admin Router Server Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
+          "url": "d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -871,7 +871,7 @@
           "keepTime": true,
           "title": "Admin Router: Details DC/OS Component Proxy Overview",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-by-node/adminrouter-details-dc-os-component-proxy-overview"
+          "url": "d/adminrouter-details-upstream-by-node/adminrouter-details-dc-os-component-proxy-overview"
         }
       ],
       "nullPointMode": "null",
@@ -1057,7 +1057,7 @@
           "keepTime": true,
           "title": "Admin Router: Details DC/OS Component Proxy Overview",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-by-node/adminrouter-details-dc-os-component-proxy-overview"
+          "url": "d/adminrouter-details-upstream-by-node/adminrouter-details-dc-os-component-proxy-overview"
         }
       ],
       "nullPointMode": "null",
@@ -1172,7 +1172,7 @@
           "keepTime": true,
           "title": "Admin Router: Details DC/OS Component Proxy Overview",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-by-node/adminrouter-details-dc-os-component-proxy-overview"
+          "url": "d/adminrouter-details-upstream-by-node/adminrouter-details-dc-os-component-proxy-overview"
         }
       ],
       "nullPointMode": "null",
@@ -1310,7 +1310,7 @@
           "keepTime": true,
           "title": "Admin Router: Details DC/OS Service Proxy Overview",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-status/adminrouter-details-dc-os-service-proxy-overview"
+          "url": "d/adminrouter-details-service-status/adminrouter-details-dc-os-service-proxy-overview"
         }
       ],
       "nullPointMode": "null",
@@ -1495,7 +1495,7 @@
           "keepTime": true,
           "title": "Admin Router: Details DC/OS Service Proxy Overview",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-status/adminrouter-details-dc-os-service-proxy-overview"
+          "url": "d/adminrouter-details-service-status/adminrouter-details-dc-os-service-proxy-overview"
         }
       ],
       "nullPointMode": "null",
@@ -1612,7 +1612,7 @@
           "keepTime": true,
           "title": "Admin Router: Details DC/OS Service Proxy Overview",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-status/adminrouter-details-dc-os-service-proxy-overview"
+          "url": "d/adminrouter-details-service-status/adminrouter-details-dc-os-service-proxy-overview"
         }
       ],
       "nullPointMode": "null",

--- a/dashboards/AdminRouter/AdminRouter-Summary.json
+++ b/dashboards/AdminRouter/AdminRouter-Summary.json
@@ -171,7 +171,7 @@
           "keepTime": true,
           "title": "Admin Router: Details Runtime",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-runtime/adminrouter-details-runtime"
+          "url": "d/adminrouter-details-runtime/adminrouter-details-runtime"
         }
       ],
       "nullPointMode": "null",
@@ -295,7 +295,7 @@
           "keepTime": true,
           "title": "Admin Router: Details Runtime",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-runtime/adminrouter-details-runtime"
+          "url": "d/adminrouter-details-runtime/adminrouter-details-runtime"
         }
       ],
       "nullPointMode": "null",
@@ -420,7 +420,7 @@
           "keepTime": true,
           "title": "Admin Router: Details Runtime",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-runtime/adminrouter-adminrouter-details-runtime"
+          "url": "d/adminrouter-details-runtime/adminrouter-adminrouter-details-runtime"
         }
       ],
       "nullPointMode": "null",
@@ -547,7 +547,7 @@
           "keepTime": true,
           "title": "Admin Router: Details Traffic",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-traffic/adminrouter-details-traffic"
+          "url": "d/adminrouter-details-traffic/adminrouter-details-traffic"
         }
       ],
       "nullPointMode": "null",
@@ -677,7 +677,7 @@
           "keepTime": true,
           "title": "Admin Router: Details Admin Router Server Status",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
+          "url": "d/adminrouter-details-server-status/adminrouter-details-adminrouter-server-status"
         }
       ],
       "nullPointMode": "null",
@@ -811,7 +811,7 @@
           "keepTime": true,
           "title": "Admin Router: Details DC/OS Component Proxy Overview",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-upstream-by-node/adminrouter-details-dc-os-component-proxy-overview"
+          "url": "d/adminrouter-details-upstream-by-node/adminrouter-details-dc-os-component-proxy-overview"
         }
       ],
       "nullPointMode": "null",
@@ -955,7 +955,7 @@
           "keepTime": true,
           "title": "Admin Router: Details DC/OS Service Proxy Overview",
           "type": "dashboard",
-          "url": "/service/beta-dcos-monitoring/grafana/d/adminrouter-details-service-status/adminrouter-details-dc-os-service-proxy-overview"
+          "url": "d/adminrouter-details-service-status/adminrouter-details-dc-os-service-proxy-overview"
         }
       ],
       "nullPointMode": "null",


### PR DESCRIPTION
This PR changes Admin Router dashboard linking from absolute links to relative links. This avoids changing the framework name to break linking between dashboards.