### PR TITLE
DCOS-55819 Fix Fluent Bit summary dashboard

### DIFF
--- a/dashboards/Fluent-Bit-Summary.json
+++ b/dashboards/Fluent-Bit-Summary.json
@@ -377,7 +377,7 @@
   "templating": {
     "list": [
       {
-        "allValue": "",
+        "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,


### PR DESCRIPTION
We need to explicitly set the 'custom all value' to '.*' so that the
URL doesn't contain all the nodes' names which leads to a too long URL
and eventually to a query error when deployed on a cluster with many
nodes.