### PR TITLE
[[--wip--]] storage: enhance uptime metrics

### DIFF
--- a/dashboards/Storage-Summary.json
+++ b/dashboards/Storage-Summary.json
@@ -86,7 +86,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
         "h": 5,
@@ -112,7 +112,13 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "resets",
+          "stack": true,
+          "yaxis": 2
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -120,9 +126,26 @@
         {
           "expr": "dss_sched_uptime",
           "format": "time_series",
+          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "this-instance",
           "refId": "A"
+        },
+        {
+          "expr": "dss_sched_latest_uptime",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "since-last-reset",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(resets(dss_sched_uptime{DCOS_SERVICE_NAME=\"storage\"}[7d]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "resets",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -149,7 +172,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": "0",
+          "min": null,
           "show": true
         },
         {
@@ -157,7 +180,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         }
       ],

--- a/dashboards/Storage-Summary.json
+++ b/dashboards/Storage-Summary.json
@@ -124,7 +124,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "dss_sched_uptime",
+          "expr": "sum(dss_sched_uptime)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -132,7 +132,7 @@
           "refId": "A"
         },
         {
-          "expr": "dss_sched_latest_uptime",
+          "expr": "sum(dss_sched_latest_uptime)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "since-last-reset",

--- a/dashboards/Storage-Summary.json
+++ b/dashboards/Storage-Summary.json
@@ -86,7 +86,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 5,


### PR DESCRIPTION
* remove fixed min for left y-axis so that an increasing uptime is easier to see
* add latest uptime (uptime since last session reset for the current container)
* right y-axis shows total resets over the last 7 days

![image](https://user-images.githubusercontent.com/2348332/60540970-6accf300-9cde-11e9-884f-aa242abfb74f.png)
