### PR TITLE
add edgelb cloud controller dashboard

### DIFF
--- a/dashboards/Edge-LB/Edge-LB-Cloud-Controller.json
+++ b/dashboards/Edge-LB/Edge-LB-Cloud-Controller.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1567531701947,
+  "iteration": 1567762970525,
   "links": [],
   "panels": [
     {
@@ -84,7 +84,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 7
       },
       "id": 28,
       "panels": [],
@@ -102,7 +102,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 6
+        "y": 8
       },
       "id": 8,
       "legend": {
@@ -186,7 +186,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 6
+        "y": 8
       },
       "id": 24,
       "legend": {
@@ -271,7 +271,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 17
       },
       "id": 12,
       "legend": {
@@ -367,7 +367,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 26
       },
       "id": 14,
       "panels": [],
@@ -385,7 +385,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 25
+        "y": 27
       },
       "id": 18,
       "legend": {
@@ -470,7 +470,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 25
+        "y": 27
       },
       "id": 16,
       "legend": {
@@ -556,7 +556,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 34
+        "y": 36
       },
       "id": 20,
       "legend": {
@@ -641,7 +641,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 34
+        "y": 36
       },
       "id": 22,
       "legend": {
@@ -667,7 +667,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "100.0 - (\r\nsum(rate(dcos_edgelb_grpc_server_handling_seconds_bucket{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\", grpc_method=\"UpdateMetadata\", le=\"1\"}[5m])) by (grpc_service)\r\n / \r\nsum(rate(dcos_edgelb_grpc_server_handling_seconds_count{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\", grpc_method=\"UpdateMetadata\"}[5m])) by (grpc_service)\r\n) * 100.0",
+          "expr": "sum(rate(dcos_edgelb_grpc_server_handling_seconds_bucket{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\", grpc_method=\"UpdateMetadata\", le=\"1\"}[5m])) by (grpc_service) \r\n - \r\nsum(rate(dcos_edgelb_grpc_server_handling_seconds_count{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\", grpc_method=\"UpdateMetadata\"}[5m])) by (grpc_service)\r\n",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -678,7 +678,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Percentage of Slow Unary Queries (>1s)",
+      "title": "Slow Unary Queries (>1s)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -694,11 +694,11 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "ops",
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -721,7 +721,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 45
       },
       "id": 4,
       "panels": [],
@@ -740,7 +740,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 44
+        "y": 46
       },
       "id": 2,
       "interval": "",
@@ -825,7 +825,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 44
+        "y": 46
       },
       "id": 6,
       "interval": "",
@@ -884,11 +884,11 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "ops",
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -916,7 +916,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 53
+        "y": 55
       },
       "id": 30,
       "legend": {
@@ -1116,5 +1116,5 @@
   "timezone": "",
   "title": "Edge-LB: Cloud Controller",
   "uid": "dUK7xrOWk",
-  "version": 5
+  "version": 4
 }

--- a/dashboards/Edge-LB/Edge-LB-Cloud-Controller.json
+++ b/dashboards/Edge-LB/Edge-LB-Cloud-Controller.json
@@ -1,0 +1,1091 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.3.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1566913686790,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 28,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "dcos_edgelb_dirty_pool_load_balancers{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{dcos_cluster_name}}:{{applicationPath}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Number of Pending Pool Load Balancers",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(dcos_edgelb_pool_updates_total{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\", poolName=~\"$poolName\"}[5m])) by(kind, poolName)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{poolName}}:{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Pool Update Inbound Rate from APIServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(dcos_edgelb_dropped_metadata_updates_total{component=~\"cloud-controller\",applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\"}[1m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "dropped",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(dcos_edgelb_processed_metadata_updates_total{component=~\"cloud-controller\",applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\"}[1m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "update",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(dcos_edgelb_ineffective_metadata_updates_total{component=~\"cloud-controller\",applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\"}[1m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "ineffective",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Metadata Update Rate from Lbmgr",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 14,
+      "panels": [],
+      "title": "gRPC Server",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(dcos_edgelb_grpc_server_handled_total{component=~\"cloud-controller\",applicationPath=~\"$applicationPath\",dcos_cluster_name=~\"$dcos_cluster_name\",grpc_method=~\"$grpc_method\"}[5m])) by (grpc_service)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{grpc_service}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "gRPC Request Inbound Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(dcos_edgelb_grpc_server_handled_total{component=\"cloud-controller\",applicationPath=~\"$applicationPath\",dcos_cluster_name=~\"$dcos_cluster_name\", grpc_type=\"unary\", grpc_code!=\"OK\", grpc_method=~\"$grpc_method\"}[5m])) by (grpc_service)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{grpc_service}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unary Request Error Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(dcos_edgelb_grpc_server_msg_sent_total{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", grpc_type=\"server_stream\", dcos_cluster_name=~\"$dcos_cluster_name\"}[10m])) by (grpc_service)\r\n /\r\nsum(rate(dcos_edgelb_grpc_server_started_total{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", grpc_type=\"server_stream\", dcos_cluster_name=~\"$dcos_cluster_name\"}[10m])) by (grpc_service)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{grpc_service}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average Response Stream Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "100.0 - (\r\nsum(rate(dcos_edgelb_grpc_server_handling_seconds_bucket{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\", grpc_method=\"UpdateMetadata\", le=\"1\"}[5m])) by (grpc_service)\r\n / \r\nsum(rate(dcos_edgelb_grpc_server_handling_seconds_count{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\", grpc_method=\"UpdateMetadata\"}[5m])) by (grpc_service)\r\n) * 100.0",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{grpc_service}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Percentage of Slow Unary Queries (>1s)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 4,
+      "panels": [],
+      "repeat": null,
+      "title": "Cloud Provider AWS API Request",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "id": 2,
+      "interval": "",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(dcos_edgelb_cloud_provider_aws_api_requests_total{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\"}[1m])) by (request)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{request}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "AWS API Query Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 6,
+      "interval": "",
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(dcos_edgelb_cloud_provider_aws_api_request_duration_seconds_bucket{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\", le=\"+Inf\"}[5m])) by (request) - sum(irate(dcos_edgelb_cloud_provider_aws_api_request_duration_seconds_bucket{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\", le=\"1\"}[5m])) by (request)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{request}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "AWS queries taking longer than 1s",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 30,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(dcos_edgelb_cloud_provider_aws_api_request_errors_total{component=~\"cloud-controller\", applicationPath=~\"$applicationPath\", dcos_cluster_name=~\"$dcos_cluster_name\"}[1m])) by (request)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{request}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "AWS API Query Error Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [
+    "edge-lb"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "DC/OS Cluster",
+        "multi": true,
+        "name": "dcos_cluster_name",
+        "options": [],
+        "query": "label_values(dcos_cluster_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Application path",
+        "multi": true,
+        "name": "applicationPath",
+        "options": [],
+        "query": "label_values(applicationPath)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pool name",
+        "multi": true,
+        "name": "poolName",
+        "options": [],
+        "query": "label_values(poolName)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "gRPC Method",
+        "multi": true,
+        "name": "grpc_method",
+        "options": [],
+        "query": "label_values(grpc_method)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Edge-LB: Cloud Controller",
+  "uid": "dUK7xrOWk",
+  "version": 1
+}

--- a/dashboards/Edge-LB/Edge-LB-Cloud-Controller.json
+++ b/dashboards/Edge-LB/Edge-LB-Cloud-Controller.json
@@ -11,6 +11,12 @@
   ],
   "__requires": [
     {
+      "type": "panel",
+      "id": "dashlist",
+      "name": "Dashboard list",
+      "version": "5.0.0"
+    },
+    {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
@@ -46,16 +52,39 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1566913686790,
+  "iteration": 1567531701947,
   "links": [],
   "panels": [
+    {
+      "folderId": null,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "headings": true,
+      "id": 32,
+      "limit": 10,
+      "links": [],
+      "query": "",
+      "recent": false,
+      "search": true,
+      "starred": false,
+      "tags": [
+        "edge-lb"
+      ],
+      "title": "Edge-LB dashboards",
+      "transparent": true,
+      "type": "dashlist"
+    },
     {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 5
       },
       "id": 28,
       "panels": [],
@@ -73,7 +102,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 1
+        "y": 6
       },
       "id": 8,
       "legend": {
@@ -157,7 +186,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 1
+        "y": 6
       },
       "id": 24,
       "legend": {
@@ -242,7 +271,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 15
       },
       "id": 12,
       "legend": {
@@ -338,7 +367,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 24
       },
       "id": 14,
       "panels": [],
@@ -356,7 +385,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 25
       },
       "id": 18,
       "legend": {
@@ -441,7 +470,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 20
+        "y": 25
       },
       "id": 16,
       "legend": {
@@ -527,7 +556,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 29
+        "y": 34
       },
       "id": 20,
       "legend": {
@@ -612,7 +641,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 29
+        "y": 34
       },
       "id": 22,
       "legend": {
@@ -692,7 +721,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 43
       },
       "id": 4,
       "panels": [],
@@ -711,7 +740,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 44
       },
       "id": 2,
       "interval": "",
@@ -796,7 +825,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 44
       },
       "id": 6,
       "interval": "",
@@ -887,7 +916,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 53
       },
       "id": 30,
       "legend": {
@@ -1087,5 +1116,5 @@
   "timezone": "",
   "title": "Edge-LB: Cloud Controller",
   "uid": "dUK7xrOWk",
-  "version": 1
+  "version": 5
 }


### PR DESCRIPTION
add the dashboard of Edge-LB cloud controller, part of APIServer

## Corresponding Ticket (required)

These DC/OS JIRA ticket(s) must be updated (ideally closed) at the moment this PR lands:

  - [DCOS-54022](https://jira.mesosphere.com/browse/DCOS-54022) Create Grafana Dashboards for cloud-controller