### PR TITLE
Fix hardcoded dashboard ID

### DIFF
--- a/dashboards/Networking/Networking-Calico.json
+++ b/dashboards/Networking/Networking-Calico.json
@@ -51,7 +51,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 57,
+  "id": null,
   "iteration": 1577785150444,
   "links": [],
   "panels": [


### PR DESCRIPTION
One of the dashboards has a hardcoded "id" field, which prevents it from being imported with Grafana dashboard api as a new dashboard.

Currently it affects `dcos-monitoring` service and its CI e2e tests. When it's configured to load dashboards from this repository, it can't complete the deployment plan due to this error in `reload-dashboard-configs` task: 
>Failed to update dashboards: Invalid HTTP response: 404 Not Found '{"message":"Dashboard not found","status":"not-found"}'
