### PR TITLE
Use mem_rss_bytes as the metric for memory usage

### DIFF
--- a/dashboards/Mesos-Containers-Details.json
+++ b/dashboards/Mesos-Containers-Details.json
@@ -354,7 +354,7 @@
           "refId": "A"
         },
         {
-          "expr": "mem_total_bytes{service_name=~\"$service\", task_name=~\"$task_name\", instance=~\"$instance\", container_id=~\"$container_id\"}",
+          "expr": "mem_rss_bytes{service_name=~\"$service\", task_name=~\"$task_name\", instance=~\"$instance\", container_id=~\"$container_id\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/dashboards/Mesos-Containers-Summary.json
+++ b/dashboards/Mesos-Containers-Summary.json
@@ -384,7 +384,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(mem_total_bytes{service_name=~\"$service\", task_name=~\"$task_name\", instance=~\"$instance\", container_id=~\"$container_id\"})",
+          "expr": "sum(mem_rss_bytes{service_name=~\"$service\", task_name=~\"$task_name\", instance=~\"$instance\", container_id=~\"$container_id\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
`mem_total_bytes` is the total usable main memory size and cannot present the used memory correctly.

From the mesos source code: https://github.com/apache/mesos/blob/master/3rdparty/stout/include/stout/os/linux.hpp#L240,
``` 
memory.total = Bytes(info.totalram * info.mem_unit);
```
From linux manual https://man7.org/linux/man-pages/man2/sysinfo.2.html, info.totalram  is total usable main memory size. 
So in order to represent the memory usage, `mem_total_bytes` is not appropriate.  

While `mem_rss_bytes` has been used in mesos ui as the memory usage: https://github.com/apache/mesos/blob/master/src/webui/app/agents/agent.html#L152