### PR TITLE
Add CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: minimal
+
+script: jq '[.id, input_filename, input_line_number]' $(find . -type f -name '*.json')  -c | grep -v null && exit 1 || echo OK


### PR DESCRIPTION
Fail when dashboard have id

It happen at least 3 times that we merged a dashboard with id that prevents dcos-monitoring dashboard update plugin from work with a cryptic 404 error.

1. #108
2. https://github.com/dcos/grafana-dashboards/pull/100
3. https://github.com/dcos/grafana-dashboards/pull/43